### PR TITLE
Delta-t enforcement

### DIFF
--- a/aframe/pipelines/sandbox/sandbox.cfg
+++ b/aframe/pipelines/sandbox/sandbox.cfg
@@ -31,7 +31,7 @@ batch_size = 512
 prior = priors.priors.end_o3_ratesandpops
 
 # data conditioning / preprocessing parameters
-sample_rate = 2048
+sample_rate = 4096
 fduration = 1
 highpass = 32
 

--- a/aframe/pipelines/sandbox/sandbox.cfg
+++ b/aframe/pipelines/sandbox/sandbox.cfg
@@ -31,7 +31,7 @@ batch_size = 512
 prior = priors.priors.end_o3_ratesandpops
 
 # data conditioning / preprocessing parameters
-sample_rate = 4096
+sample_rate = 2048
 fduration = 1
 highpass = 32
 

--- a/projects/plots/poetry.lock
+++ b/projects/plots/poetry.lock
@@ -4195,4 +4195,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.11"
-content-hash = "0ca4b590f97f9fca56ded85e09478d6fbd00661e103074e6f2855affc705af83"
+content-hash = "ed3c8b6d2979f4d91c28e01652b1d1293ed394f8700b2b7bab084389e5753982"

--- a/projects/plots/pyproject.toml
+++ b/projects/plots/pyproject.toml
@@ -22,6 +22,9 @@ lalsuite = "^7.19"
 jsonargparse = "^4.27.4"
 utils = {path = "../utils", develop = true}
 
+[tool.poetry.group.dev.dependencies]
+jupyter = "^1.0.0"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Allow specification of `dt` parameter in sensitive volume estimation code that doesn't count foreground events if the recovered time is greater than `dt` from the injected time