### PR TITLE
Condor memory issues

### DIFF
--- a/aframe/pipelines/sandbox/sandbox.cfg
+++ b/aframe/pipelines/sandbox/sandbox.cfg
@@ -53,9 +53,12 @@ max_duration = &::luigi_base::max_duration
 flag = &::luigi_base::flag
 ifos = &::luigi_base::ifos
 channels = &::luigi_base::channels
+request_memory = 3GB
+request_disk = 1024KB
+request_cpus = 1
 
 [luigi_TrainingWaveforms]
-num_signals = 100000
+num_signals = 1000
 sample_rate = &::luigi_base::sample_rate
 waveform_duration = &::luigi_base::waveform_duration
 minimum_frequency = &::luigi_base::minimum_frequency
@@ -86,7 +89,9 @@ min_duration = 128
 max_duration = &::luigi_base::max_duration
 flag = &::luigi_base::flag
 channels = &::luigi_base::channels
-
+request_memory = 3GB
+request_disk = 1024KB
+request_cpus = 1
 
 [luigi_TimeslideWaveforms]
 workflow = htcondor
@@ -107,6 +112,9 @@ reference_frequency = &::luigi_base::reference_frequency
 waveform_duration = &::luigi_base::waveform_duration
 waveform_approximant = &::luigi_base::waveform_approximant
 highpass = &::luigi_base::highpass
+request_memory = 0.5MB
+request_disk = 1024KB
+request_cpus = 1
 
 [luigi_SandboxExport]
 fduration = &::luigi_base::fduration

--- a/aframe/pipelines/sandbox/sandbox.cfg
+++ b/aframe/pipelines/sandbox/sandbox.cfg
@@ -53,7 +53,7 @@ max_duration = &::luigi_base::max_duration
 flag = &::luigi_base::flag
 ifos = &::luigi_base::ifos
 channels = &::luigi_base::channels
-request_memory = 3GB
+request_memory = 6GB
 request_disk = 1024KB
 request_cpus = 1
 
@@ -89,7 +89,7 @@ min_duration = 128
 max_duration = &::luigi_base::max_duration
 flag = &::luigi_base::flag
 channels = &::luigi_base::channels
-request_memory = 3GB
+request_memory = 6GB
 request_disk = 1024KB
 request_cpus = 1
 
@@ -112,7 +112,7 @@ reference_frequency = &::luigi_base::reference_frequency
 waveform_duration = &::luigi_base::waveform_duration
 waveform_approximant = &::luigi_base::waveform_approximant
 highpass = &::luigi_base::highpass
-request_memory = 0.5MB
+request_memory = 6GB
 request_disk = 1024KB
 request_cpus = 1
 

--- a/aframe/pipelines/sandbox/sandbox.cfg
+++ b/aframe/pipelines/sandbox/sandbox.cfg
@@ -58,7 +58,7 @@ request_disk = 1024KB
 request_cpus = 1
 
 [luigi_TrainingWaveforms]
-num_signals = 1000
+num_signals = 100000
 sample_rate = &::luigi_base::sample_rate
 waveform_duration = &::luigi_base::waveform_duration
 minimum_frequency = &::luigi_base::minimum_frequency
@@ -69,7 +69,7 @@ prior = &::luigi_base::prior
 [luigi_ValidationWaveforms]
 workflow = htcondor
 num_jobs = 20
-num_signals = 1000
+num_signals = 20000
 ifos = &::luigi_base::ifos
 highpass = &::luigi_base::highpass
 sample_rate = &::luigi_base::sample_rate
@@ -165,7 +165,7 @@ sequence_id = 1001
 
 [logging]
 law: INFO 
-#law.sandbox.base: DEBUG
+law.sandbox.base: INFO
 law.patches: INFO
 luigi-interface: INFO
-#law.workflow.base: DEBUG
+law.workflow.base: INFO

--- a/aframe/tasks/data/condor/base.py
+++ b/aframe/tasks/data/condor/base.py
@@ -19,6 +19,8 @@ class LDGCondorWorkflow(htcondor.HTCondorWorkflow):
     request_memory = luigi.Parameter(default="32678")
     request_cpus = luigi.IntParameter(default=1)
 
+    exclude_params_req = {"request_memory", "request_disk", "request_cpus"}
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.htcondor_log_dir.touch()

--- a/aframe/tasks/data/fetch.py
+++ b/aframe/tasks/data/fetch.py
@@ -6,12 +6,12 @@ from luigi.util import inherits
 
 from aframe.targets import s3_or_local
 from aframe.tasks.data.base import AframeDataTask
-from aframe.tasks.data.condor.workflows import DynamicMemoryWorklow
+from aframe.tasks.data.condor.workflows import StaticMemoryWorkflow
 from aframe.tasks.data.segments import Query
 
 
 @inherits(Query)
-class Fetch(law.LocalWorkflow, DynamicMemoryWorklow, AframeDataTask):
+class Fetch(law.LocalWorkflow, StaticMemoryWorkflow, AframeDataTask):
     data_dir = luigi.Parameter()
     sample_rate = luigi.FloatParameter()
     max_duration = luigi.FloatParameter(default=-1)

--- a/aframe/tasks/data/timeslide_waveforms/timeslide_waveforms.py
+++ b/aframe/tasks/data/timeslide_waveforms/timeslide_waveforms.py
@@ -179,7 +179,12 @@ class TimeslideWaveforms(AframeDataTask):
         ]
 
     def requires(self):
-        return DeployTimeslideWaveforms.req(self)
+        return DeployTimeslideWaveforms.req(
+            self,
+            request_memory=self.request_memory,
+            request_disk=self.request_disk,
+            request_cpus=self.request_cpus,
+        )
 
     @property
     def targets(self):


### PR DESCRIPTION
Address memory issues for condor workflow tasks. Condor computing request parameters are no longer passed between tasks via `.req()`