### PR TITLE
Parameterize number of injection shifts by `num_injections`

### DIFF
--- a/aframe/pipelines/sandbox/sandbox.cfg
+++ b/aframe/pipelines/sandbox/sandbox.cfg
@@ -95,7 +95,7 @@ request_cpus = 1
 
 [luigi_TimeslideWaveforms]
 workflow = htcondor
-Tb = &::luigi_base::Tb
+num_injections = 100000
 shifts = &::luigi_base::shifts
 spacing = 16
 buffer = 16

--- a/aframe/pipelines/tune/tune.cfg
+++ b/aframe/pipelines/tune/tune.cfg
@@ -73,7 +73,7 @@ channels = &::luigi_base::channels
 
 [luigi_TimeslideWaveforms]
 workflow = htcondor
-Tb = &::luigi_base::Tb
+num_injections = 100000
 shifts = &::luigi_base::shifts
 spacing = 16
 buffer = 16

--- a/aframe/tasks/data/timeslide_waveforms/timeslide_waveforms.py
+++ b/aframe/tasks/data/timeslide_waveforms/timeslide_waveforms.py
@@ -47,7 +47,7 @@ class DeployTimeslideWaveforms(
     StaticMemoryWorkflow,
 ):
     def workflow_requires(self):
-        reqs = super().workflow_requires()
+        reqs = {}
         reqs["test_segments"] = FetchTest.req(
             self,
             segments_file=os.path.join(self.output_dir, "segments.txt"),
@@ -103,6 +103,7 @@ class DeployTimeslideWaveforms(
             self.num_injections,
             self.spacing,
             self.max_shift,
+            self.buffer,
         )
 
     @property

--- a/aframe/tasks/data/timeslide_waveforms/timeslide_waveforms.py
+++ b/aframe/tasks/data/timeslide_waveforms/timeslide_waveforms.py
@@ -22,7 +22,7 @@ class TimeSlideWaveformsParams(law.Task):
     start = luigi.FloatParameter()
     end = luigi.FloatParameter()
     ifos = luigi.ListParameter()
-    Tb = luigi.FloatParameter()
+    num_injections = luigi.IntParameter()
     output_dir = luigi.Parameter()
     shifts = luigi.ListParameter()
     spacing = luigi.FloatParameter()
@@ -98,8 +98,11 @@ class DeployTimeslideWaveforms(
 
     @property
     def shifts_required(self):
-        return utils.get_num_shifts(
-            self.test_segments, self.Tb, self.max_shift
+        return utils.get_num_shifts_from_num_injections(
+            self.test_segments,
+            self.num_injections,
+            self.spacing,
+            self.max_shift,
         )
 
     @property

--- a/aframe/tasks/infer/infer.py
+++ b/aframe/tasks/infer/infer.py
@@ -138,7 +138,9 @@ class InferLocal(InferBase):
         from aframe import utils
 
         segments = utils.segments_from_paths(self.background_fnames)
-        num_shifts = utils.get_num_shifts(segments, self.Tb, max(self.shifts))
+        num_shifts = utils.get_num_shifts_from_Tb(
+            segments, self.Tb, max(self.shifts)
+        )
 
         background_fnames = [f.path for f in self.background_fnames]
         deploy_local(
@@ -239,7 +241,9 @@ class InferRemote(InferBase):
 
         # infer segment start and stop times directly from file names
         segments = utils.segments_from_paths(self.background_fnames)
-        num_shifts = utils.get_num_shifts(segments, self.Tb, max(self.shifts))
+        num_shifts = utils.get_num_shifts_from_Tb(
+            segments, self.Tb, max(self.shifts)
+        )
 
         background_fnames = [f.path for f in self.background_fnames]
         deploy_remote(

--- a/aframe/utils.py
+++ b/aframe/utils.py
@@ -95,12 +95,33 @@ def calc_shifts_required(Tb: float, T: float, delta: float) -> int:
     return math.ceil(N)
 
 
-def get_num_shifts(
+def get_num_shifts_from_Tb(
     segments: List[Tuple[float, float]], Tb: float, shift: float
 ) -> int:
     """
     Calculates the number of required time shifts based on a list
-    of background segments
+    of background segments and the desired total background duration.
     """
     T = sum([stop - start for start, stop in segments])
     return calc_shifts_required(Tb, T, shift)
+
+
+def get_num_shifts_from_num_injections(
+    segments,
+    num_injections: int,
+    spacing: float,
+    shift: float,
+    buffer: float,
+) -> int:
+    """
+    Calculates the number of required time shifts based on a list
+    of background segments, injection spacing, and the desired total
+    number of injections
+    """
+    T = sum([stop - start for start, stop in segments])
+    a = -shift / 2
+    b = T - 2 * buffer - (shift / 2)
+    c = -num_injections * spacing
+    discriminant = b**2 - 4 * a * c
+    N = math.ceil(-b + discriminant**0.5) / (2 * a)
+    return N

--- a/aframe/utils.py
+++ b/aframe/utils.py
@@ -122,6 +122,6 @@ def get_num_shifts_from_num_injections(
     a = -shift / 2
     b = T - 2 * buffer - (shift / 2)
     c = -num_injections * spacing
-    discriminant = b**2 - 4 * a * c
-    N = math.ceil(-b + discriminant**0.5) / (2 * a)
-    return N
+    discriminant = (b**2) - 4 * a * c
+    N = (-b + (discriminant**0.5)) / (2 * a)
+    return math.ceil(N)

--- a/libs/ledger/poetry.lock
+++ b/libs/ledger/poetry.lock
@@ -945,6 +945,17 @@ docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.link
 testing = ["jaraco.test (>=5.4)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)", "zipp (>=3.17)"]
 
 [[package]]
+name = "iniconfig"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
+
+[[package]]
 name = "ipykernel"
 version = "6.29.4"
 description = "IPython Kernel for Jupyter"
@@ -2117,6 +2128,21 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4.3)", "pytest-
 type = ["mypy (>=1.8)"]
 
 [[package]]
+name = "pluggy"
+version = "1.5.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
+    {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
 name = "prometheus-client"
 version = "0.20.0"
 description = "Python client for the Prometheus monitoring system."
@@ -2235,6 +2261,28 @@ files = [
 
 [package.extras]
 diagrams = ["jinja2", "railroad-diagrams"]
+
+[[package]]
+name = "pytest"
+version = "8.2.0"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-8.2.0-py3-none-any.whl", hash = "sha256:1733f0620f6cda4095bbf0d9ff8022486e91892245bb9e7d5542c018f612f233"},
+    {file = "pytest-8.2.0.tar.gz", hash = "sha256:d507d4482197eac0ba2bae2e9babf0672eb333017bcedaa5fb1a3d42c1174b3f"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=1.5,<2.0"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -3038,4 +3086,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.11"
-content-hash = "a403ca0b8f3d975726e38298e82efbb8dbf7742cb15917326d1b9b3bc82b5283"
+content-hash = "66b8016770b8648873836940d6055998c31fc41584153ab65ccf7a658cef0853"

--- a/libs/ledger/pyproject.toml
+++ b/libs/ledger/pyproject.toml
@@ -14,6 +14,7 @@ h5py = "^3.10.0"
 
 [tool.poetry.group.dev.dependencies]
 jupyter = "^1.0.0"
+pytest = "^8.2.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/libs/ledger/tests/test_events.py
+++ b/libs/ledger/tests/test_events.py
@@ -19,6 +19,20 @@ class TestEventSet:
         shifts = np.split(obj1.shift, 2)
         assert (shifts[0] == shifts[1] * -1).all()
 
+        # test with empty object
+        obj1 = events.EventSet()
+        det_stats, times, shifts = (
+            np.array([1, 2, 3]),
+            np.array([4, 5, 6]),
+            np.array([7, 8, 9]),
+        )
+        obj2 = events.EventSet(det_stats, times, shifts, 100)
+        obj2.append(obj1)
+        assert obj2.Tb == 100
+        assert (obj2.detection_statistic == det_stats).all()
+        assert (obj2.detection_time == times).all()
+        assert (obj2.shift == shifts).all()
+
     def test_nb(self):
         det_stats = np.arange(10)
         times = np.arange(10)

--- a/projects/infer/infer/data.py
+++ b/projects/infer/infer/data.py
@@ -1,3 +1,4 @@
+import logging
 import math
 from contextlib import nullcontext
 from typing import Optional
@@ -23,8 +24,12 @@ class Sequence:
     ):
         """
         Object used for iterating over a segment of data,
-        performing timeshifts, injecting waveforms, and
+        performing timeshifts, optionally injecting waveforms, and
         aggregating the returned inference outputs.
+
+        If the injection set is empty for this given
+        segment and shifts, infernece on injections will be skipped,
+        and `None` will be returned for the foreground events.
 
         Args:
             background_fname:
@@ -56,13 +61,26 @@ class Sequence:
             self.t0 = dataset.attrs["x0"]
             self.duration = self.size / self.sample_rate
 
-        # use this to load in our injections up front
-        self.injection_set = LigoResponseSet.read(
+        # load in our injections up front
+        # if there are no injections for
+        # this shift, set it to None so
+        # we don't run inference on injections
+        injection_set = LigoResponseSet.read(
             injection_set_fname,
             start=self.t0,
             end=self.t0 + self.duration,
             shifts=shifts,
         )
+
+        if not len(injection_set):
+            logging.info(
+                f"No injections found in {injection_set_fname} "
+                f"for segment {background_fname} and "
+                f"shifts {shifts}, skipping."
+            )
+            injection_set = None
+
+        self.injection_set = injection_set
 
         # derive some properties from that metadata,
         # including come up with a semi-unique sequence
@@ -83,6 +101,12 @@ class Sequence:
             self._started[seq_id] = False
             self._done[seq_id] = False
             self._sequences[seq_id] = np.zeros(size)
+
+        # if there are no injections, we can mark
+        # the injection sequence as started and done
+        if self.injection_set is None:
+            self._done[self.id + 1] = True
+            self._started[self.id + 1] = True
 
     @property
     def started(self):
@@ -152,9 +176,14 @@ class Sequence:
                     x.append(data)
                 x = np.stack(x).astype(np.float32)
 
-                # injection any waveforms into a copy of the background
+                # if there are any injections for this shift,
+                # inject waveforms into a copy of the background
+                x_inj = None
                 offset = i * self.batch_size / self.inference_sampling_rate
-                x_inj = self.injection_set.inject(x.copy(), self.t0 + offset)
+                if self.injection_set is not None:
+                    x_inj = self.injection_set.inject(
+                        x.copy(), self.t0 + offset
+                    )
 
                 # return the two sets of updates, possibly
                 # rate limited if we specified a max rate
@@ -179,10 +208,11 @@ class Sequence:
         # sequences have completed, return them both,
         # slicing off the dummy data from the last batch
         if self.done:
-            return tuple(
-                self._sequences[self.id + i][: -self.num_slice]
-                for i in range(2)
-            )
+            background = self._sequences[self.id][: -self.num_slice]
+            foreground = None
+            if self.injection_set is not None:
+                foreground = self._sequences[self.id + 1][: -self.num_slice]
+            return tuple(background, foreground)
 
     def recover(self, foreground: EventSet) -> RecoveredInjectionSet:
         return RecoveredInjectionSet.recover(foreground, self.injection_set)

--- a/projects/infer/infer/main.py
+++ b/projects/infer/infer/main.py
@@ -53,13 +53,14 @@ def infer(
             sequence_end=sequence_end,
         )
 
-        client.infer(
-            x_inj,
-            request_id=i,
-            sequence_id=sequence.id + 1,
-            sequence_start=sequence_start,
-            sequence_end=sequence_end,
-        )
+        if x_inj is not None:
+            client.infer(
+                x_inj,
+                request_id=i,
+                sequence_id=sequence.id + 1,
+                sequence_start=sequence_start,
+                sequence_end=sequence_end,
+            )
 
         # wait for the first response to come back
         # for both sequences to allow for some

--- a/projects/infer/infer/postprocess.py
+++ b/projects/infer/infer/postprocess.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 from ledger.events import EventSet
 
@@ -104,7 +106,13 @@ class Postprocessor:
         shifts = np.ones((len(events), len(self.shifts))) * self.shifts
         return EventSet(events, times, shifts, Tb)
 
-    def __call__(self, y):
+    def __call__(self, y: Optional[np.ndarray] = None) -> EventSet:
+        # in the case where we didn't perform
+        # injections on this shift
+        # just return an empty event set
+        if y is None:
+            return EventSet()
+
         y = y[self.offset :]
         y = self.integrate(y)
         y = self.cluster(y)

--- a/projects/train/poetry.lock
+++ b/projects/train/poetry.lock
@@ -2716,10 +2716,10 @@ tbb = "==2021.*"
 
 [[package]]
 name = "ml4gw"
-version = "0.3.0"
+version = "0.4.2"
 description = "Tools for training torch models on gravitational wave data"
 optional = false
-python-versions = "^3.8"
+python-versions = "^3.8,<3.12"
 files = []
 develop = true
 


### PR DESCRIPTION
Closes #123 #122 

Parameterizes number of injection shifts we do based on `num_injections` parameter instead of `Tb`

The inference code will skip over the injection portion for any segment/shift combinations that do not have injections in the `injectio_set` file