### PR TITLE
Added p_astro function

### DIFF
--- a/projects/plots/plots/p_astro.py
+++ b/projects/plots/plots/p_astro.py
@@ -1,0 +1,19 @@
+from ledger.events import EventSet, F, RecoveredInjectionSet
+from ledger.injections import InjectionParameterSet
+
+
+def compute_p_astro(
+    background: EventSet,
+    foreground: RecoveredInjectionSet,
+    rejected_params: InjectionParameterSet,
+    detection_statistic: F,
+    injected_volume: float,
+    astro_event_rate: float,
+) -> F:
+    n_inj = len(foreground) + len(rejected_params)
+    events_above_statistic = foreground.nb(detection_statistic)
+    sensitive_volume = injected_volume * events_above_statistic / n_inj
+    foreground_rate = sensitive_volume * astro_event_rate
+    background_rate = background.far(detection_statistic)
+
+    return foreground_rate / (foreground_rate + background_rate)

--- a/projects/plots/plots/p_astro.py
+++ b/projects/plots/plots/p_astro.py
@@ -1,19 +1,55 @@
+import numpy as np
 from ledger.events import EventSet, F, RecoveredInjectionSet
 from ledger.injections import InjectionParameterSet
 
 
 def compute_p_astro(
+    detection_statistic: F,
     background: EventSet,
     foreground: RecoveredInjectionSet,
     rejected_params: InjectionParameterSet,
-    detection_statistic: F,
     injected_volume: float,
     astro_event_rate: float,
+    min_det_stat: float = -np.inf,
 ) -> F:
+    """
+    Compute p_astro as the ratio of the expected signal rate
+    to the sum of the expected signal rate and the expected
+    background event rate for a given set of detection
+    statistics
+
+    Args:
+        detection_statistic:
+            A value or set of values for which to calculate the
+            corresponding p_astro
+        background:
+            EventSet object corresponding to a background model
+        foreground:
+            RecoveredInjectionSet object corresponding to an
+            injection campaign
+        rejected_params:
+            InjectionParameterSet object corresponding to signals
+            that were simulated but rejected due to low SNR
+        injected_volume:
+            The astrophysical volume into which injections were
+            made during the injection campaign
+        astro_event_rate:
+            The rate density of events for the relavent population.
+            Should have the same spatial units as injected_volume
+        min_det_stat:
+            Then minimum detection statistic for which to compute
+            p_astro. Detection statistics below this value will
+            be assigned a p_astro of 0
+    """
+    p_astro = np.zeros_like(detection_statistic)
+    mask = detection_statistic >= min_det_stat
+    detection_statistic = detection_statistic[mask]
+
     n_inj = len(foreground) + len(rejected_params)
     events_above_statistic = foreground.nb(detection_statistic)
     sensitive_volume = injected_volume * events_above_statistic / n_inj
     foreground_rate = sensitive_volume * astro_event_rate
     background_rate = background.far(detection_statistic)
 
-    return foreground_rate / (foreground_rate + background_rate)
+    p_astro[mask] += foreground_rate / (foreground_rate + background_rate)
+    return p_astro

--- a/projects/plots/poetry.lock
+++ b/projects/plots/poetry.lock
@@ -11,6 +11,7 @@ develop = true
 
 [package.dependencies]
 boto3 = "^1.34.4"
+cloudpathlib = "^0.18.1"
 kr8s = "^0.10.0"
 law = "^0.1"
 luigi = "^3.0"
@@ -444,6 +445,7 @@ files = [
     {file = "bilby.cython-0.4.2-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:61d839dc6ce4716cd2a8207d33fb7dd89cba7520d02555a23b74b046e1536fab"},
     {file = "bilby.cython-0.4.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78555e9d1a7cb6072912bbf71922d8d316f66a8ad5c3b754c490157b62f60d3b"},
     {file = "bilby.cython-0.4.2-cp311-cp311-win_amd64.whl", hash = "sha256:d8d00c9a4e47abe05ed83e75b29017d35e0ee8df564838161e44d78af5ad2122"},
+    {file = "bilby.cython-0.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:b824e1751c8b944134406109d59f439dd59343e4dd8d21c8e9a2ebba81748a4f"},
     {file = "bilby.cython-0.4.2-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:df11fd6bf289083f2c8530c783ccdebbc5d59ff4925f4c2de7c6a82989fd598e"},
     {file = "bilby.cython-0.4.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc3be34dd988db8484f77aba19af1c88b393d88f49fcfb3c034bfc32f834b6d0"},
     {file = "bilby.cython-0.4.2-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:f512a7f23771d67b136c35271ef2f1027292368b051e91357f85f39425b4b9ba"},
@@ -709,6 +711,26 @@ files = [
     {file = "charset_normalizer-3.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d"},
     {file = "charset_normalizer-3.3.2-py3-none-any.whl", hash = "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc"},
 ]
+
+[[package]]
+name = "cloudpathlib"
+version = "0.18.1"
+description = "pathlib-style classes for cloud storage services."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "cloudpathlib-0.18.1-py3-none-any.whl", hash = "sha256:20efd5d772c75df91bb2ac52e053be53fd9000f5e9755fd92375a2a9fe6005e0"},
+    {file = "cloudpathlib-0.18.1.tar.gz", hash = "sha256:ffd22f324bfbf9c3f2bc1bec6e8372cb372a0feef17c7f2b48030cd6810ea859"},
+]
+
+[package.dependencies]
+typing_extensions = {version = ">4", markers = "python_version < \"3.11\""}
+
+[package.extras]
+all = ["cloudpathlib[azure]", "cloudpathlib[gs]", "cloudpathlib[s3]"]
+azure = ["azure-storage-blob (>=12)"]
+gs = ["google-cloud-storage"]
+s3 = ["boto3"]
 
 [[package]]
 name = "colorama"
@@ -2507,10 +2529,10 @@ files = [
 
 [[package]]
 name = "ml4gw"
-version = "0.3.0"
+version = "0.4.2"
 description = "Tools for training torch models on gravitational wave data"
 optional = false
-python-versions = "^3.8"
+python-versions = "^3.8,<3.12"
 files = []
 develop = true
 
@@ -2960,6 +2982,7 @@ description = "Nvidia JIT LTO Library"
 optional = false
 python-versions = ">=3"
 files = [
+    {file = "nvidia_nvjitlink_cu12-12.4.99-py3-none-manylinux2014_aarch64.whl", hash = "sha256:75d6498c96d9adb9435f2bbdbddb479805ddfb97b5c1b32395c694185c20ca57"},
     {file = "nvidia_nvjitlink_cu12-12.4.99-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c6428836d20fe7e327191c175791d38570e10762edc588fb46749217cd444c74"},
     {file = "nvidia_nvjitlink_cu12-12.4.99-py3-none-win_amd64.whl", hash = "sha256:991905ffa2144cb603d8ca7962d75c35334ae82bf92820b6ba78157277da1ad2"},
 ]


### PR DESCRIPTION
Adds a function to calculate `p_astro` given a detection statistic, an astrophysical event rate, and the data products of an injection campaign.

To-do:
- [x] The function calculating `nb` can end up requiring a lot of memory. E.g., if we want the FAR of 1e6 foreground events and there are 4e6 background events, which is roughly typical, than it requires ~4 TB of memory. On the other hand, having this function vectorized makes it faster for large numbers of events. We'll need some kind of workaround if we want to calculate `p_astro` of all the events in an injection campaign.
- [x] Is this the best place for this function to live? Might be better over in `utils`
- [ ] What's the appropriate event rate to be using? Doesn't make a huge difference to the SV at `p_astro > 0.5`, but would be good to establish roughly how this number is chosen. I've been using 30 Gpc^-3 yr^-1 based on Table 4 of this [paper](https://dcc.ligo.org/public/0177/P2100239/011/o3_population.pdf)
