### PR TITLE
Helper script for building containers

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3464,6 +3464,17 @@ files = [
 ]
 
 [[package]]
+name = "spython"
+version = "0.3.13"
+description = "Command line python tool for working with singularity."
+optional = false
+python-versions = "*"
+files = [
+    {file = "spython-0.3.13-py3-none-any.whl", hash = "sha256:3c16e05261647dc4f5931d641adb179f21b4bd117572c161bdf54fe511cda4d8"},
+    {file = "spython-0.3.13.tar.gz", hash = "sha256:931105675f7889705e50859df72f01b8e00b5ad92ab2e5d9ef47563343419e4e"},
+]
+
+[[package]]
 name = "stack-data"
 version = "0.6.3"
 description = "Extract data from python stack frames and tracebacks for informative displays"
@@ -3861,4 +3872,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.11"
-content-hash = "0bd8ddf42e3e7a3303b7e2ed2208ba43bc9cb34241d0dfcaf6e13bf56e00492f"
+content-hash = "d394c7056d0537f67791eef6c3b3983837f1b6e8eb705b5f77e038beda50bb4b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ pykube-ng = {version = "^23.6.0", extras = ["oidc"]}
 boto3 = "^1.34.4"
 numpy = "^1.26.4"
 cloudpathlib = "^0.18.1"
+spython = "^0.3.13"
 
 
 [tool.poetry.group.dev.dependencies]
@@ -24,6 +25,9 @@ jupyter = "^1.0.0"
 jsonargparse = "^4.27.1"
 conda-lock = "^2.5.1"
 pre-commit = "^3.7.0"
+
+[tool.poetry.scripts]
+build-containers = "scripts.build_containers:main"
 
 [build-system]
 requires = ["poetry-core"]

--- a/scripts/build_containers.py
+++ b/scripts/build_containers.py
@@ -33,6 +33,7 @@ def build_container(project_name: str, container_root: Path) -> str:
         )
         return out
 
+    # build the container
     try:
         Client.build(
             image=str(container_path),
@@ -47,6 +48,15 @@ def build_container(project_name: str, container_root: Path) -> str:
         os.chdir(cwd)
 
 
+def validate_projects(projects: List[str]) -> None:
+    invalid = [p for p in projects if p not in PROJECTS]
+    if invalid:
+        raise ValueError(
+            f"Specified invalid projects: {', '.join(invalid)}. "
+            f"The available projects are: {', '.join(PROJECTS)}"
+        )
+
+
 def build(projects: List[str], container_root: Path, max_workers: int) -> None:
     if not container_root:
         logging.info("Container root path is not set.")
@@ -56,7 +66,6 @@ def build(projects: List[str], container_root: Path, max_workers: int) -> None:
         futures = {
             executor.submit(build_container, project, container_root): project
             for project in projects
-            if project in PROJECTS
         }
         for future in as_completed(futures):
             project = futures[future]
@@ -102,6 +111,8 @@ def main():
 
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)
+
+    validate_projects(args.projects)
     build(args.projects, args.container_root, args.max_workers)
 
 

--- a/scripts/build_containers.py
+++ b/scripts/build_containers.py
@@ -1,0 +1,86 @@
+import logging
+import os
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+from typing import List
+
+from jsonargparse import ArgumentParser
+from spython.main import Client
+
+# Define the directory where the projects are located
+BASE_DIR: Path = Path(__file__).resolve().parent.parent / "projects"
+
+# List of all available project names
+PROJECTS: List[str] = [x.name for x in BASE_DIR.iterdir() if x.is_dir()]
+
+
+def build_container(project_name: str, container_root: Path) -> str:
+    project_path: Path = BASE_DIR / project_name
+    container_path: Path = container_root / f"{project_name}.sif"
+
+    if not container_path.exists():
+        return f"Container for {project_name} does not exist. Skipping build."
+
+    try:
+        Client.build(
+            image=str(container_path),
+            recipe=str(project_path / "apptainer.def"),
+            sudo=False,
+            options=["--force"],
+        )
+        return f"Successfully built container for {project_name}"
+    except Exception as e:
+        return f"Failed to build container for {project_name}: {e}"
+
+
+def build(projects: List[str], container_root: Path) -> None:
+    if not container_root:
+        logging.info("Container root path is not set.")
+        return
+
+    with ProcessPoolExecutor() as executor:
+        futures = {
+            executor.submit(build_container, project, container_root): project
+            for project in projects
+            if project in PROJECTS
+        }
+        for future in as_completed(futures):
+            project = futures[future]
+            try:
+                result = future.result()
+                logging.info(result)
+            except Exception as exc:
+                logging.info(
+                    f"Project {project} generated an exception: {exc}"
+                )
+
+
+def main():
+    parser = ArgumentParser(
+        description="Automatically rebuild Aframe "
+        "apptainer images for sub-projects"
+    )
+
+    parser.add_argument(
+        "projects",
+        nargs="*",
+        default=PROJECTS,
+        help="List of projects to build. "
+        f"Default is all: {', '.join(PROJECTS)}",
+    )
+
+    parser.add_argument(
+        "--container-root",
+        type=Path,
+        default=Path(os.getenv("AFRAME_CONTAINER_ROOT", "")),
+        help="Path to the container root directory. "
+        "Defaults to the $AFRAME_CONTAINER_ROOT environment variable.",
+    )
+
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO)
+    build(args.projects, args.container_root)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_containers.py
+++ b/scripts/build_containers.py
@@ -92,7 +92,7 @@ def main():
 
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)
-    build(args.projects, args.container_root)
+    build(args.projects, args.container_root, args.max_workers)
 
 
 if __name__ == "__main__":

--- a/scripts/build_containers.py
+++ b/scripts/build_containers.py
@@ -35,12 +35,12 @@ def build_container(project_name: str, container_root: Path) -> str:
         return f"Failed to build container for {project_name}: {e}"
 
 
-def build(projects: List[str], container_root: Path) -> None:
+def build(projects: List[str], container_root: Path, max_workers: int) -> None:
     if not container_root:
         logging.info("Container root path is not set.")
         return
 
-    with ProcessPoolExecutor() as executor:
+    with ProcessPoolExecutor(max_workers=max_workers) as executor:
         futures = {
             executor.submit(build_container, project, container_root): project
             for project in projects
@@ -77,6 +77,15 @@ def main():
         default=Path(os.getenv("AFRAME_CONTAINER_ROOT", "")),
         help="Path to the container root directory. "
         "Defaults to the $AFRAME_CONTAINER_ROOT environment variable.",
+    )
+
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=None,  # Set a default number of workers
+        help="Maximum number of concurrent builds. Can be useful to set if "
+        "your local TMPDIR is being overfilled when building containers. "
+        "Default is `None`.",
     )
 
     args = parser.parse_args()

--- a/scripts/build_containers.py
+++ b/scripts/build_containers.py
@@ -15,9 +15,9 @@ PROJECTS: List[str] = [x.name for x in BASE_DIR.iterdir() if x.is_dir()]
 
 
 def build_container(project_name: str, container_root: Path) -> str:
-    project_path: Path = BASE_DIR / project_name
-    container_path: Path = container_root / f"{project_name}.sif"
-
+    project_path = BASE_DIR / project_name
+    container_path = container_root / f"{project_name}.sif"
+    definition_path = project_path / "apptainer.def"
     # change directory to project path since
     # that's the root from where
     # the apptainer def files are defined
@@ -26,7 +26,7 @@ def build_container(project_name: str, container_root: Path) -> str:
 
     # skip this project if there
     # is no associated apptainer definition file
-    if not container_path.exists():
+    if not definition_path.exists():
         out = (
             f"Apptainer definition file for {project_name} "
             "does not exist. Skipping build."
@@ -37,7 +37,7 @@ def build_container(project_name: str, container_root: Path) -> str:
     try:
         Client.build(
             image=str(container_path),
-            recipe=str(project_path / "apptainer.def"),
+            recipe=str(definition_path),
             sudo=False,
             options=["--force"],
         )

--- a/scripts/build_containers.py
+++ b/scripts/build_containers.py
@@ -19,7 +19,9 @@ def build_container(project_name: str, container_root: Path) -> str:
     container_path: Path = container_root / f"{project_name}.sif"
 
     if not container_path.exists():
-        return f"Container for {project_name} does not exist. Skipping build."
+        out = f"Apptainer definition file for {project_name} "
+        "does not exist. Skipping build."
+        return out
 
     try:
         Client.build(

--- a/scripts/build_containers.py
+++ b/scripts/build_containers.py
@@ -18,6 +18,14 @@ def build_container(project_name: str, container_root: Path) -> str:
     project_path: Path = BASE_DIR / project_name
     container_path: Path = container_root / f"{project_name}.sif"
 
+    # change directory to project path since
+    # that's the root from where
+    # the apptainer def files are defined
+    cwd = os.getcwd()
+    os.chdir(project_path)
+
+    # skip this project if there
+    # is no associated apptainer definition file
     if not container_path.exists():
         out = (
             f"Apptainer definition file for {project_name} "
@@ -35,6 +43,8 @@ def build_container(project_name: str, container_root: Path) -> str:
         return f"Successfully built container for {project_name}"
     except Exception as e:
         return f"Failed to build container for {project_name}: {e}"
+    finally:
+        os.chdir(cwd)
 
 
 def build(projects: List[str], container_root: Path, max_workers: int) -> None:

--- a/scripts/build_containers.py
+++ b/scripts/build_containers.py
@@ -19,8 +19,10 @@ def build_container(project_name: str, container_root: Path) -> str:
     container_path: Path = container_root / f"{project_name}.sif"
 
     if not container_path.exists():
-        out = f"Apptainer definition file for {project_name} "
-        "does not exist. Skipping build."
+        out = (
+            f"Apptainer definition file for {project_name} "
+            "does not exist. Skipping build."
+        )
         return out
 
     try:


### PR DESCRIPTION
Little helper CLI utility for easily rebuilding containers. By default, will build all containers, storing them in `$AFRAME_CONTAINER_ROOT`. The `--container-root` can be overridden at the command line. To only build certain projects, just name them explicitly, e.g.

`poetry run build-containers export train`