### PR TITLE
Add `aframe-init` CLI tool for initializing directory with config files to launch pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Once setup, create a [fork](https://docs.github.com/en/pull-requests/collaborati
 git clone git@github.com:albert-einstein/aframev2.git
 ```
 
-Set the `AFRAME_REPO` environment variable in your `~/.bash_profile` to point to the location where you cloned the repository.
+Set the `AFRAME_REPO` environment variable in your `~/.bash_profile` to point to the location where you cloned the repository. 
 
 `Aframe` utilizes `git` [submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules). Make sure to initialize and update those
 
@@ -38,15 +38,35 @@ git submodule update --init
 When pulling changes from this repository, it's recommended to use the `--recurse-submodules` flag to pull any updates from the submodules as well.
 
 Next, in the root of the repository, install the base `aframe` `poetry` environment.
-```
+
+```bash
 poetry install
 ```
-This environment is used to launch `luigi`/`law` tasks and pipelines. See this [README](./aframe) for more information.
 
-Next, follow the [instructions](./projects/README.md) for building each project's Apptainer images, and familiarize yourself with the various projects. These images are used as environments for running `Aframe` workflows, and thus are necessary to build. Once complete, you are all setup! 
+This environment is used to launch `luigi`/`law` tasks and pipelines (See this [README](./aframe) for more information), and also contains other helpful command line utilities for building project container images, and initializing directories with configuration files for various analyses. 
 
-The default Aframe experiment is the [`sandbox`](./aframe/pipelines/sandbox/) pipeline found under `aframe/pipelines/sandbox`. First follow the general instructions in the aframe [README](./aframe), and then the instructions in the sandbox [README](./aframe/pipelines/sandbox/) to execute the pipeline as an introduction to interacting with the respository. 
+You can now build each of the project apptainer container images. Set the `AFRAME_CONTAINER_ROOT` environment variable where the image files will be stored. We recommend Something like `~/aframe/images`. This might take ~ 10 minutes, so grab a coffee!
 
+```bash
+poetry run build-containers 
+```
+
+These images are containerized environments for running `Aframe` tasks in isolation, and thus are necessary to build. For more information on what is happening under the hood, please see the projects [README](./projects/README.md). Once complete, you are all setup! 
+
+
+The default `Aframe` experiment is the [`sandbox`](./aframe/pipelines/sandbox/) pipeline found under `aframe/pipelines/sandbox`. You can intialize a run directory with default configuration files using the `aframe-init` command line utility
+
+```bash
+poetry run aframe-init sandbox --directory ~/aframe/runs/my-first-run/
+```
+
+This will create configuration files and a bash executable to launch the pipeline. Feel free to edit the configuration files! Launch the pipeline via
+
+```bash
+bash ~/aframe/runs/my-first-run/run.sh
+```
+
+Please see the instructions in the sandbox [README](./aframe/pipelines/sandbox/) for more details.
 
 ## Repository structure
 The code here is structured like a [monorepo](https://medium.com/opendoor-labs/our-python-monorepo-d34028f2b6fa), with applications siloed off into isolated environments to keep dependencies lightweight, but built on top of a shared set of libraries to keep the code modular and consistent. Briefly, the repository consists of three main sub-directories:

--- a/aframe/pipelines/sandbox/README.md
+++ b/aframe/pipelines/sandbox/README.md
@@ -22,7 +22,7 @@ uses a `yaml` file. See the [`config.yaml`](../../../projects/train/config.yaml)
 
 > **_Note: Parameters that are common between training and other tasks (e.g. ifos, highpass, fduration) are specified once in the `.cfg` and automatically passed to the downstream training or tuning `config.yaml` by `luigi`/`law`_**
 
-The `aframe-init` command line tool can be used to initialize a directory with configuration files for a fresh run. In the specified directory, `aframe-init` will create default `.cfg` and `.yaml` configuration files, as well as a `run.sh` file for launching the pipeline.
+The `aframe-init` command line tool can be used to initialize a directory with configuration files for a fresh run. In the specified directory, `aframe-init` will create default `.cfg` and `.yaml` configuration files, as well as a `run.sh` file for launching the pipeline. Ensure you are in the root of the repository when using `aframe-init`.
 
 ```bash
 poetry run aframe-init sandbox --directory ~/aframe/my-first-run/ 

--- a/aframe/pipelines/sandbox/README.md
+++ b/aframe/pipelines/sandbox/README.md
@@ -1,33 +1,43 @@
-# Sandbox Pipeline
+# Pipelines
 
 > **_Note: It is highly recommended that you have completed the [ml4gw quickstart](https://github.com/ml4gw/quickstart/) instructions before running the sandbox pipeline_**
 
 > **_Note: It is assumed that you have already built each [project's container](../../../projects/README.md)_**
 
-The sandbox pipeline strings together `luigi` / `law` tasks to run an end-to-end generic aframe workflow.
+Pipelines string together `luigi` / `law` tasks to run an end-to-end generic aframe workflow.
 In short, running the sandbox pipeline will
 
 1. Generate training data 
 2. Generate testing data
-3. Train a model
+3. Train or Tune a model
 4. Export trained weights to TensorRT
 5. Perform inference using Triton
 6. Calculate sensitive volume
 
 ## Pipeline Configuration
-The pipeline is configured by two files. A `.cfg` file contains the parameters
-for the data generation, export, and inference tasks. See the [`sandbox.cfg`](./sandbox.cfg) for a complete example.
+The pipeline is configured by two main configuration files. A `.cfg` file is used by `law`, and contains the parameters
+for the data generation, export, and inference tasks. See the [`bbh.cfg`](./configs/bbh.cfg) for a complete example.
 Training configuration is handled by [`lightning`](https://lightning.ai/docs/pytorch/stable/), which 
-uses a `yaml` file. By default, the Sandbox pipeline will use the [`config.yaml`](../../../projects/train/config.yaml) that lives at the root of the train project. If you wish to point to a different location, you can set the `config` parameter of the `luigi_Train` task in the `.cfg`:
+uses a `yaml` file. See the [`config.yaml`](../../../projects/train/config.yaml) that lives at the root of the train project for an example. 
 
-```cfg
-[luigi_Train]
-config = /path/to/training/config.yaml
+> **_Note: Parameters that are common between training and other tasks (e.g. ifos, highpass, fduration) are specified once in the `.cfg` and automatically passed to the downstream training or tuning `config.yaml` by `luigi`/`law`_**
+
+The `aframe-init` command line tool can be used to initialize a directory with configuration files for a fresh run. In the specified directory, `aframe-init` will create default `.cfg` and `.yaml` configuration files, as well as a `run.sh` file for launching the pipeline.
+
+```bash
+poetry run aframe-init sandbox --directory ~/aframe/my-first-run/ 
 ```
 
-> **_Note: Parameters that are common between training and other tasks (e.g. ifos, highpass, fduration) are specified once in the `.cfg` and passed to the downstream training `config.yaml` by `luigi`/`law`_**
+You can also initialize a directory for launching the tune pipeline
 
-Lastly, environment variables are used to control locations of data and analysis artifcats throughout the run:
+```bash
+poetry run aframe-init tune --directory ~/aframe/my-first-tune-run/ 
+```
+
+You can now edit these files as you wish.
+
+In the created `run.sh` file, the below environment variables set based on the intialization directory.
+They are used to control locations of data and analysis artifcats throughout the run.
 
 - `AFRAME_TRAIN_DATA_DIR` Training data storage
 - `AFRAME_TEST_DATA_DIR` Testing data storage
@@ -36,37 +46,18 @@ Lastly, environment variables are used to control locations of data and analysis
 - `AFRAME_RESULTS_DIR` Inference and sensitive volume results
 - `AFRAME_TMPDIR` Intermediate data product storage 
 
-
-It is recommended to store these in a `.env` file. The following pattern could prove useful:
-
-```bash
-AFRAME_BASE=~/aframe # base location for aframe runs
-RUN_LABEL=my_first_run # some descriptive label for this analysis
-export AFRAME_TRAIN_DATA_DIR=$AFRAME_BASE/$RUN_LABEL/data/train
-export AFRAME_TEST_DATA_DIR=$AFRAME_BASE/$RUN_LABEL/data/test
-export AFRAME_TRAIN_RUN_DIR=$AFRAME_BASE/$RUN_LABEL/training
-export AFRAME_CONDOR_DIR=$AFRAME_BASE/$RUN_LABEL/condor
-export AFRAME_RESULTS_DIR=$AFRAME_BASE/$RUN_LABEL/results
-export AFRAME_TMPDIR=$AFRAME_BASE/$RUN_LABEL/data/tmp/
-```
-
-To export these environment variables, simply run
-
-```
-source .env
-```
-
 ## Running the Pipeline
-To launch the pipeline, ensure that you are in the root level of the repository.
-Then, the pipeline can be launched using `poetry` and the `law` command line tool.
-
 > **_NOTE: Running the sandbox pipeline out-of-the-box requires access to an enterprise-grade GPU(s) (e.g. P100, V100, T4, A[30,40,100], etc.). There are several nodes on the LIGO Data Grid which meet these requirements_**.
 
+The bottom of the `run.sh` contains the command that launches the pipeline. It should look something like
+
+```bash
+LAW_CONFIG_FILE=~/aframe/my-first-run/sandbox.cfg \
+poetry run --directory $AFRAME_REPO \
+law run aframe.pipelines.sandbox.Sandbox --workers 5 --gpus 0,1
 ```
-LAW_CONFIG_FILE=/path/to/sandbox.cfg \
-    poetry run law run aframe.pipelines.sandbox.Sandbox
-    --gpus 0,1 --workers 5
-```
+
+Edit the `workers` and `gpus` arguments to suit your needs.
 
 The `workers` argument specifies how many `luigi` workers to use. This controls how many concurrent tasks 
 can be launched. It is useful to specify more than 1 worker when you have several tasks that are not dependent on one another. 
@@ -74,60 +65,64 @@ can be launched. It is useful to specify more than 1 worker when you have severa
 The `gpus` argument controls which gpus to use for training and inference. Under the hood, the pipeline is simply setting
 the `CUDA_VISIBLE_DEVICES` environment variable. 
 
-The end to end pipeline can take a few days to run. The most time consuming steps are training and performing inference. If you wish to reduce these timescales for testing the end-to-end analysis, consider altering the
-[`max_epochs`](../../../projects/train/config.yaml#92) argument in the training configuration file, and/or the amount of analyzed livetime ([`Tb`](./sandbox.cfg#17)) in the sandbox config.
+The pipeline can now be kicked off by executing the `run.sh` 
+
+```bash
+bash ~/aframe/my-first-run/run.sh
+```
+
+The end to end pipeline can take a few days to run. The most time consuming steps are training and performing inference. If you wish to reduce these timescales for testing the end-to-end analysis, consider altering the following arguments:
+- [`max_epochs`](../../../projects/train/config.yaml#92) in the training `yaml` configuration file
+- the amount of analyzed background livetime ([`Tb`](./configs/base.cfg#17)) 
+- the number of injections ([`num_injections`](./configs/base.cfg#101))
 
 
 ## Remote Training
-Model training can be run on the nautilus hypercluster simply by setting the `AFRAME_TRAIN_RUN_DIR` and `AFRAME_TRAIN_DATA_DIR` environment variables to point to an s3 path.
+If you've successfully followed the [ml4gw quickstart](https://github.com/ml4gw/quickstart/),
+model training or tuning can be run on the nautilus hypercluster. 
+
+To initialize your run directory for a remote run, use the optional `--s3-bucket` argument to `aframe-init`
 
 ```bash
-export AFRAME_TRAIN_DATA_DIR=s3://{your-bucket}/$RUN_LABEL/data
-export AFRAME_TRAIN_RUN_DIR=s3://{your-bucket}/$RUN_LABEL/training
+poetry run aframe-init sandbox --directory ~/aframe/my-first-run --s3-bucket s3://my-bucket/my-first-run
 ```
 
-The `law` `Tasks` responsible for training data generation will automatically transfer your data to s3 storage. The
-rest of the pipeline (export, inference, etc.) is compatible with s3 storage and will work out of the box.
+This will configure the `AFRAME_TRAIN_RUN_DIR` and `AFRAME_TRAIN_DATA_DIR` in the `run.sh` to point to the specified remote s3 bucket.
 
-It is also possible to train locally on the LDG using a remote dataset. The training code will automatically download the dataset from s3.
+The `luigi`/`law` `Tasks` responsible for training data generation will automatically transfer your data to s3 storage, and launch a remote training job
+using kubernetes. The rest of the pipeline (export, inference, etc.) is compatible with s3 storage and will work out of the box.
 
 
 ## Tips and Tricks
+It is also possible to train locally on the LDG using a remote s3 dataset. The training code will automatically download the dataset from s3.
+
+
 If you wish to launch an analysis with the freedom of ending
 your ssh session, you can use a tool like [`tmux`](https://github.com/tmux/tmux/wiki). Note that `tmux`
 is already installed on the LDG clusters.
 
-First, create a new session and ensure you are in the root of the aframe repository
-```
-tmux new -s aframe-sandbox
+First, create a new `tmux` session 
+
+```bash
+tmux new -s my-first-run
 ```
 
-Next, ensure that you've re-sourced your .env!
-```
-source /path/to/.env
-```
+Then, launch the pipeline
 
-Finally, launch the analysis
-```
-LAW_CONFIG_FILE=/path/to/sandbox.cfg \
-    poetry run law run aframe.pipelines.sandbox.Sandbox
-    --gpus 0,1 --workers 5
+```bash
+bash ~/aframe/my-first-run/run.sh
 ```
 
 Use `Ctrl` + `b` `d` to exit the `tmux` session. To re-attach simply run
 
-```
+```bash
 tmux a
 ```
+
 to attach to your latest session, or 
 
-```
-tmux a -t aframe-analysis
+```bash
+tmux a -t my-first-run
 ```
 
 to re-attach to a session by name
-
-
-
-
-    

--- a/aframe/pipelines/sandbox/configs/tune.cfg
+++ b/aframe/pipelines/sandbox/configs/tune.cfg
@@ -4,9 +4,8 @@ local_scheduler = true
 module = aframe
 log_level = INFO
 
-# inherit from base config, 
-# which defines parameters for most tasks;
-# any parameters can be overwritten in this config
+[core]
+# this needs to be an absolute path
 inherit = $AFRAME_REPO/aframe/pipelines/sandbox/configs/base.cfg
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ pre-commit = "^3.7.0"
 
 [tool.poetry.scripts]
 build-containers = "scripts.build_containers:main"
+aframe-init = "scripts.aframe_init:main"
 
 [build-system]
 requires = ["poetry-core"]

--- a/scripts/aframe_init.py
+++ b/scripts/aframe_init.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+
+import configparser
+import shutil
+from pathlib import Path
+from typing import Optional
+
+import jsonargparse
+
+root = Path(__file__).resolve().parent.parent
+TUNE_CONFIGS = [
+    root / "aframe" / "pipelines" / "sandbox" / "configs" / "tune.cfg",
+    root / "aframe" / "pipelines" / "sandbox" / "configs" / "base.cfg",
+    root / "projects" / "train" / "config.yaml",
+    root / "projects" / "train" / "train" / "tune" / "search_space.py",
+]
+
+SANDBOX_CONFIGS = [
+    root / "aframe" / "pipelines" / "sandbox" / "configs" / "bbh.cfg",
+    root / "aframe" / "pipelines" / "sandbox" / "configs" / "base.cfg",
+    root / "projects" / "train" / "config.yaml",
+]
+
+
+def copy_configs(
+    path: Path,
+    configs: list[Path],
+    pipeline: str,
+    s3_bucket: Optional[Path] = None,
+):
+    """
+    Copy the configuration files to the specified directory for editing.
+
+    Any path specific configurations will be updated to point to the
+    correct paths in the new directory.
+
+    Args:
+        path:
+            The directory to copy the configuration files to.
+        configs:
+            The list of configuration files to copy.
+        pipeline:
+            The type of pipeline to initialize. Either 'tune' or 'sandbox'.
+        s3_bucket:
+            The s3 bucket to store the data and
+            training results in. Defaults to None.
+    """
+
+    path.mkdir(parents=True, exist_ok=True)
+    for config in configs:
+        dest = path / config.name
+        # update the config file to point to the paths
+        # of the config files in the init dir
+        if config.suffix == ".cfg" and config.name != "base.cfg":
+            cfg = configparser.ConfigParser()
+            cfg.read(config)
+            cfg["core"]["inherit"] = str(path / "base.cfg")
+
+            train_task = (
+                "luigi_Train" if pipeline == "sandbox" else "luigi_TuneRemote"
+            )
+            cfg[train_task]["config"] = str(path / "config.yaml")
+
+            if s3_bucket is not None:
+                cfg["luigi_Train"]["train_remote"] = "true"
+
+            with open(dest, "w") as f:
+                cfg.write(f)
+        else:
+            shutil.copy(config, dest)
+
+
+def create_env(path: Path, s3_bucket: Optional[Path] = None):
+    # if s3 bucket is provided
+    # store training data and training info there
+    base = path if s3_bucket is None else s3_bucket
+    content = f"""
+# Export environment variables
+export AFRAME_TRAIN_DATA_DIR={base}/data/train
+export AFRAME_TEST_DATA_DIR={path}/data/test
+export AFRAME_TRAIN_RUN_DIR={base}/training
+export AFRAME_CONDOR_DIR={path}/condor
+export AFRAME_RESULTS_DIR={path}/results
+export AFRAME_TMPDIR={path}/tmp/
+"""
+
+    env = path / "env.env"
+    with open(env, "w") as f:
+        f.write(content)
+
+
+def main():
+    parser = jsonargparse.ArgumentParser(
+        description="Initialize a directory with configuration files "
+        "for running aframe pipelines."
+    )
+    parser.add_argument(
+        "pipeline",
+        help="The type of pipeline to initialize. "
+        "Either 'tune' or 'sandbox'. Default is sandbox",
+        default="sandbox",
+    )
+
+    parser.add_argument(
+        "-d",
+        "--directory",
+        help="The directory to initialize the aframe analysis in",
+        type=Path,
+        required=True,
+    )
+
+    parser.add_argument(
+        "--s3-bucket",
+        help="Location for storing the data and results in s3 "
+        "if training remotely. If not provided, the data and "
+        "results will be stored locally in the --directory argument",
+        required=False,
+    )
+
+    args = parser.parse_args()
+    directory = args.directory.resolve()
+    if args.pipeline not in ["tune", "sandbox"]:
+        raise ValueError(
+            "Invalid pipeline type. Must be either 'tune' or 'sandbox'."
+        )
+
+    if args.s3_bucket is not None and not args.s3_bucket.startswith("s3://"):
+        raise ValueError("S3 bucket must be in the format s3://{bucket-name}/")
+
+    copy_configs(
+        directory,
+        TUNE_CONFIGS if args.pipeline == "tune" else SANDBOX_CONFIGS,
+        args.s3_bucket,
+    )
+    create_env(directory, args.s3_bucket)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/aframe_init.py
+++ b/scripts/aframe_init.py
@@ -56,14 +56,17 @@ def copy_configs(
             cfg.read(config)
             cfg["core"]["inherit"] = str(path / "base.cfg")
 
+            # set the train config file
+            # to the one in the init directory
             train_task = (
                 "luigi_Train" if pipeline == "sandbox" else "luigi_TuneRemote"
             )
             cfg[train_task]["config"] = str(path / "config.yaml")
 
-            if s3_bucket is not None:
-                cfg["luigi_Train"]["train_remote"] = "true"
-
+            # set the search space for the tune pipeline
+            # to the search space file in the init directory
+            if pipeline == "tune":
+                cfg[train_task]["search_space"] = str(path / "search_space.py")
             with open(dest, "w") as f:
                 cfg.write(f)
         else:

--- a/scripts/aframe_init.py
+++ b/scripts/aframe_init.py
@@ -86,7 +86,7 @@ def create_runfile(
     config = path / f"{pipeline}.cfg"
     # make the below one string
     cmd = f"LAW_CONFIG_FILE={config} poetry run --directory {root} "
-    cmd += f"law run aframe.pipelines.{pipeline}.{pipeline.capitalize()} "
+    cmd += f"law run aframe.pipelines.sandbox.{pipeline.capitalize()} "
     cmd += "--workers 5 --gpus 0"
     content = f"""
     #!/bin/bash

--- a/scripts/aframe_init.py
+++ b/scripts/aframe_init.py
@@ -85,7 +85,7 @@ def create_runfile(
 
     config = path / f"{pipeline}.cfg"
     # make the below one string
-    cmd = f"LAW_CONFIG_FILE={config} poetry run --directory $AFRAME_REPO "
+    cmd = f"LAW_CONFIG_FILE={config} poetry run --directory {root} "
     cmd += f"law run aframe.pipelines.{pipeline}.{pipeline.capitalize()} "
     cmd += "--workers 5 --gpus 0"
     content = f"""

--- a/scripts/aframe_init.py
+++ b/scripts/aframe_init.py
@@ -86,7 +86,7 @@ def create_runfile(
     config = path / f"{pipeline}.cfg"
     # make the below one string
     cmd = f"LAW_CONFIG_FILE={config} poetry run --directory $AFRAME_REPO "
-    cmd += f"law runaframe.pipelines.{pipeline}.{pipeline.capitalize()} "
+    cmd += f"law run aframe.pipelines.{pipeline}.{pipeline.capitalize()} "
     cmd += "--workers 5 --gpus 0"
     content = f"""
     #!/bin/bash

--- a/scripts/aframe_init.py
+++ b/scripts/aframe_init.py
@@ -3,6 +3,7 @@
 import configparser
 import shutil
 from pathlib import Path
+from textwrap import dedent
 from typing import Optional
 
 import jsonargparse
@@ -50,8 +51,9 @@ def copy_configs(
     for config in configs:
         dest = path / config.name
         # update the config file to point to the paths
-        # of the config files in the init dir
+        # of other relevant config files in the init dir
         if config.suffix == ".cfg" and config.name != "base.cfg":
+            dest = path / f"{pipeline}.cfg"
             cfg = configparser.ConfigParser()
             cfg.read(config)
             cfg["core"]["inherit"] = str(path / "base.cfg")
@@ -74,23 +76,41 @@ def copy_configs(
             shutil.copy(config, dest)
 
 
-def create_env(path: Path, s3_bucket: Optional[Path] = None):
+def create_runfile(
+    path: Path, pipeline: str, s3_bucket: Optional[Path] = None
+):
     # if s3 bucket is provided
     # store training data and training info there
     base = path if s3_bucket is None else s3_bucket
-    content = f"""
-# Export environment variables
-export AFRAME_TRAIN_DATA_DIR={base}/data/train
-export AFRAME_TEST_DATA_DIR={path}/data/test
-export AFRAME_TRAIN_RUN_DIR={base}/training
-export AFRAME_CONDOR_DIR={path}/condor
-export AFRAME_RESULTS_DIR={path}/results
-export AFRAME_TMPDIR={path}/tmp/
-"""
 
-    env = path / "env.env"
+    config = path / f"{pipeline}.cfg"
+    # make the below one string
+    cmd = f"LAW_CONFIG_FILE={config} poetry run --directory $AFRAME_REPO "
+    cmd += f"law runaframe.pipelines.{pipeline}.{pipeline.capitalize()} "
+    cmd += "--workers 5 --gpus 0"
+    content = f"""
+    #!/bin/bash
+    # Export environment variables
+    export AFRAME_TRAIN_DATA_DIR={base}/data/train
+    export AFRAME_TEST_DATA_DIR={path}/data/test
+    export AFRAME_TRAIN_RUN_DIR={base}/training
+    export AFRAME_CONDOR_DIR={path}/condor
+    export AFRAME_RESULTS_DIR={path}/results
+    export AFRAME_TMPDIR={path}/tmp/
+
+    # launch pipeline; modify the gpus, workers etc. to suit your needs
+    # note that if you've made local code changes not in the containers
+    # you'll need to add the --dev flag!
+    {cmd}
+    """
+
+    content = dedent(content).strip("\n")
+    env = path / "run.sh"
     with open(env, "w") as f:
         f.write(content)
+
+    # make the file executable
+    env.chmod(0o755)
 
 
 def main():
@@ -137,7 +157,7 @@ def main():
         args.pipeline,
         args.s3_bucket,
     )
-    create_env(directory, args.s3_bucket)
+    create_runfile(directory, args.pipeline, args.s3_bucket)
 
 
 if __name__ == "__main__":

--- a/scripts/aframe_init.py
+++ b/scripts/aframe_init.py
@@ -67,6 +67,7 @@ def copy_configs(
             # to the search space file in the init directory
             if pipeline == "tune":
                 cfg[train_task]["search_space"] = str(path / "search_space.py")
+
             with open(dest, "w") as f:
                 cfg.write(f)
         else:
@@ -133,6 +134,7 @@ def main():
     copy_configs(
         directory,
         TUNE_CONFIGS if args.pipeline == "tune" else SANDBOX_CONFIGS,
+        args.pipeline,
         args.s3_bucket,
     )
     create_env(directory, args.s3_bucket)


### PR DESCRIPTION
Adds `aframe-init` CLI tool for initializing directory with config files to launch pipeline. As an example,

```bash
poetry run aframe-init sandbox --directory /home/ethan.marx/aframe/analysis/
```

Will copy the sandbox `base.cfg`, `bbh.cfg` and training `config.yaml` to `/home/ethan.marx/aframe/analysis/`. It will also populate a `env.env` with the appropriate environment variable paths corresponding to the `--directory` you passed.

You can also optionally specify an `--s3-bucket`

```bash
poetry run aframe-init sandbox --directory /home/ethan.marx/aframe/analysis/ --s3-bucket s3://aframe-test/test/
```

This will add set the `AFRAME_TRAIN_RUN_DIR` and `AFRAME_TRAIN_DATA_DIR` to the s3 bucket location, which will initialize remote training

To initialize a `tune` pipeline, just run 

```bash
poetry run aframe-init tune --directory /home/ethan.marx/aframe/tune/
```

This will also copy over a search_space.py file for editing.