### PR TITLE
Capture build errors

### DIFF
--- a/scripts/build_containers.py
+++ b/scripts/build_containers.py
@@ -44,9 +44,9 @@ def build_container(project_name: str, container_root: Path) -> str:
     try:
         for line in cmd:
             logging.info(line)
-        return f"Successfully built container for {project_name}", None
+        return f"Successfully built container for {project_name}"
     except Exception as e:
-        return f"Failed to build container for {project_name}: {e}", e
+        return f"Failed to build container for {project_name}: {e}"
     finally:
         os.chdir(cwd)
 
@@ -65,7 +65,7 @@ def build(projects: List[str], container_root: Path, max_workers: int) -> None:
         logging.info("Container root path is not set.")
         return
 
-    exceptions = {}
+    failed_projects = []
     with ProcessPoolExecutor(max_workers=max_workers) as executor:
         futures = {
             executor.submit(build_container, project, container_root): project
@@ -73,18 +73,18 @@ def build(projects: List[str], container_root: Path, max_workers: int) -> None:
         }
         for future in as_completed(futures):
             project = futures[future]
-            result, exc = future.result()
+            result = future.result()
             logging.info(result)
             if result.startswith("Failed"):
-                exceptions[project] = str(exc)
+                failed_projects.append(project)
 
     logging.info("Container build summary:")
-    if len(exceptions) > 0:
+    if len(failed_projects) > 0:
         logging.error(
             f"Failed to build containers for the following projects: "
-            f"{', '.join(exceptions.keys())}\n"
+            f"{', '.join(failed_projects)}\n"
             f"To retry building these containers, run the following: "
-            f"poetry run build-containers {' '.join(exceptions.keys())}"
+            f"poetry run build-containers {' '.join(failed_projects)}"
         )
     else:
         logging.info("All containers built successfully")


### PR DESCRIPTION
For whatever reason, it seems like `stream=True` needs to be set for any errors which are raised to be captured. But setting that makes the build process return an iterator, so that then needs to be looped through. The exceptions being raised weren't very helpful for debugging, so I removed them from the summary statement.