### PR TITLE
Infer `logs` dir bug fix

### DIFF
--- a/projects/infer/infer/utils.py
+++ b/projects/infer/infer/utils.py
@@ -94,7 +94,11 @@ def build_condor_submit(
     # clear out log dir due to (likely) pycondor bug
     # where previously failed jobs
     # were being interpreted as failed due to old logs
-    shutil.rmtree(log_dir / "log")
+    try:
+        shutil.rmtree(log_dir / "log")
+    except FileNotFoundError:
+        pass
+
     job = Job(
         name="infer-clients",
         executable=shutil.which("infer"),


### PR DESCRIPTION
Handle case where infer logs dir is not made already