### PR TITLE
Fixed clone and remote commands in contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,13 +10,13 @@ Here are some guidelines on how code in this repo should be structured, as well 
 To start contributing, create a [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) of this repository. You can then clone your fork
 
 ```console
-git clone git@github.com:albert-einstein/aframe.git
+git clone git@github.com:albert-einstein/aframev2.git
 ```
 
 (replacing your GitHub username for `albert-einstein`). Then, add your the main (`ML4GW`) repository as a remote reference. A common practice is to rename this remote `upstream`.
 
 ```console
-git remote add upstream git@github.com:ML4GW/aframe.git
+git remote add upstream git@github.com:ML4GW/aframev2.git
 ```
 
 Next, check out to a new branch for a _specific_ issue you're trying to solve


### PR DESCRIPTION
Changed clone and remote commands to reference  ML4GW/aframev2 rather than ML4GW/aframe