### PR TITLE
Make vetos optional in both vizapp and legacy plot script

### DIFF
--- a/projects/plots/plots/legacy/main.py
+++ b/projects/plots/plots/legacy/main.py
@@ -12,7 +12,7 @@ from ledger.events import EventSet, RecoveredInjectionSet
 from ledger.injections import InjectionParameterSet
 from plots.legacy import compute, tools
 from plots.legacy.gwtc3 import main as gwtc3_pipeline_sv
-from plots.vetos import VetoParser, get_catalog_vetos
+from plots.vetos import VETO_CATEGORIES, VetoParser, get_catalog_vetos
 from priors.priors import log_normal_masses
 
 from utils.logging import configure_logging
@@ -55,6 +55,7 @@ def main(
     max_far: float = 365,
     sigma: float = 0.1,
     verbose: bool = False,
+    vetos: Optional[List[VETO_CATEGORIES]] = None,
 ):
     """
     Compute and plot the sensitive volume of an aframe analysis
@@ -107,35 +108,38 @@ def main(
     )
     logging.info(f"Loading in vetoes from {start} to {stop}")
 
-    veto_parser = VetoParser(
-        VETO_DEFINER_FILE,
-        GATE_PATHS,
-        start,
-        stop,
-        ifos,
-    )
+    # optionally apply vetos
+    # if user passed list of veto categories
+    if vetos is not None:
+        veto_parser = VetoParser(
+            VETO_DEFINER_FILE,
+            GATE_PATHS,
+            start,
+            stop,
+            ifos,
+        )
 
-    catalog_vetos = get_catalog_vetos(start, stop)
-    categories = ["CAT1", "CAT2", "CAT3", "GATES", "CATALOG"]
-    for cat in categories:
-        for i, ifo in enumerate(ifos):
-            if cat == "CATALOG":
-                vetos = catalog_vetos
-            else:
-                vetos = veto_parser.get_vetoes(cat)[ifo]
-            back_count = len(background)
-            fore_count = len(foreground)
-            if len(vetos) > 0:
-                background = background.apply_vetos(vetos, i)
-                foreground = foreground.apply_vetos(vetos, i)
-            logging.info(
-                f"\t{back_count - len(background)} {cat} "
-                f"background events removed for ifo {ifo}"
-            )
-            logging.info(
-                f"\t{fore_count - len(foreground)} {cat} "
-                f"foreground events removed for ifo {ifo}"
-            )
+        catalog_vetos = get_catalog_vetos(start, stop)
+
+        for cat in vetos:
+            for i, ifo in enumerate(ifos):
+                if cat == "CATALOG":
+                    vetos = catalog_vetos
+                else:
+                    vetos = veto_parser.get_vetoes(cat)[ifo]
+                back_count = len(background)
+                fore_count = len(foreground)
+                if len(vetos) > 0:
+                    background = background.apply_vetos(vetos, i)
+                    foreground = foreground.apply_vetos(vetos, i)
+                logging.info(
+                    f"\t{back_count - len(background)} {cat} "
+                    f"background events removed for ifo {ifo}"
+                )
+                logging.info(
+                    f"\t{fore_count - len(foreground)} {cat} "
+                    f"foreground events removed for ifo {ifo}"
+                )
 
     logging.info("Computing data likelihood under source prior")
     source, _ = source_prior(cosmology)

--- a/projects/plots/plots/vetos/__init__.py
+++ b/projects/plots/plots/vetos/__init__.py
@@ -1,1 +1,6 @@
-from .vetos import VetoParser, gates_to_veto_segments, get_catalog_vetos
+from .vetos import (
+    VETO_CATEGORIES,
+    VetoParser,
+    gates_to_veto_segments,
+    get_catalog_vetos,
+)

--- a/projects/plots/plots/vetos/vetos.py
+++ b/projects/plots/plots/vetos/vetos.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Literal
 
 import numpy as np
 from gwosc import datasets
@@ -9,7 +9,7 @@ from gwpy.segments import DataQualityDict
 # TODO: gating should really be applied directly to the strain
 
 
-CATEGORIES = ["CAT1", "CAT2", "CAT3", "GATES"]
+VETO_CATEGORIES = Literal["CAT1", "CAT2", "CAT3", "GATES", "CATALOG"]
 
 
 def gates_to_veto_segments(path: Path):

--- a/projects/plots/plots/vizapp/app.py
+++ b/projects/plots/plots/vizapp/app.py
@@ -40,7 +40,7 @@ class App:
         valid_frac: float,
         fftlength: float,
         device: str = "cpu",
-        vetos: Optional[VETO_CATEGORIES] = None,
+        vetos: Optional["VETO_CATEGORIES"] = None,
         verbose: bool = False,
     ) -> None:
         configure_logging(verbose=verbose)

--- a/projects/plots/plots/vizapp/app.py
+++ b/projects/plots/plots/vizapp/app.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, List
+from typing import TYPE_CHECKING, Callable, List, Optional
 
 import torch
 from bokeh.layouts import column, row
@@ -13,6 +13,7 @@ from utils.s3 import open_file
 
 if TYPE_CHECKING:
     from plots.pages import Page
+    from plots.vetos import VETO_CATEGORIES
 
 
 class App:
@@ -39,7 +40,7 @@ class App:
         valid_frac: float,
         fftlength: float,
         device: str = "cpu",
-        vetos: bool = True,
+        vetos: Optional[VETO_CATEGORIES] = None,
         verbose: bool = False,
     ) -> None:
         configure_logging(verbose=verbose)

--- a/projects/plots/plots/vizapp/app.py
+++ b/projects/plots/plots/vizapp/app.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Callable, List, Optional
 import torch
 from bokeh.layouts import column, row
 from bokeh.models import Div, TabPanel, Tabs
+from plots.vetos import VETO_CATEGORIES
 from plots.vizapp.data import DataManager
 from plots.vizapp.pages import Analysis, Summary
 
@@ -13,7 +14,6 @@ from utils.s3 import open_file
 
 if TYPE_CHECKING:
     from plots.pages import Page
-    from plots.vetos import VETO_CATEGORIES
 
 
 class App:
@@ -40,7 +40,7 @@ class App:
         valid_frac: float,
         fftlength: float,
         device: str = "cpu",
-        vetos: Optional["VETO_CATEGORIES"] = None,
+        vetos: Optional[VETO_CATEGORIES] = None,
         verbose: bool = False,
     ) -> None:
         configure_logging(verbose=verbose)

--- a/projects/plots/plots/vizapp/data.py
+++ b/projects/plots/plots/vizapp/data.py
@@ -1,12 +1,13 @@
 import logging
 from copy import deepcopy
 from pathlib import Path
+from typing import Optional
 
 import numpy as np
 from bokeh.models import MultiChoice
 from ledger.events import EventSet, RecoveredInjectionSet
 from ledger.injections import InjectionParameterSet
-from plots.vetos import VetoParser
+from plots.vetos import VETO_CATEGORIES, VetoParser
 
 
 def chirp_mass(m1, m2):
@@ -38,7 +39,7 @@ class DataManager:
         results_dir: Path,
         data_dir: Path,
         ifos: list[str],
-        vetos: bool = True,
+        vetos: Optional[VETO_CATEGORIES] = None,
     ):
         self.logger = logging.getLogger("vizapp")
         self.ifos = ifos

--- a/projects/plots/plots/vizapp/data.py
+++ b/projects/plots/plots/vizapp/data.py
@@ -82,19 +82,8 @@ class DataManager:
             )
             self.calculate_veto_masks()
 
-    @property
-    def veto_options(self):
-        return [
-            "GATES",
-            "CAT1",
-            "CAT2",
-            "CAT3",
-        ]
-
     def get_veto_selecter(self):
-        return MultiChoice(
-            title="Applied Vetos", value=[], options=self.veto_options
-        )
+        return MultiChoice(title="Applied Vetos", value=[], options=self.vetos)
 
     def calculate_veto_masks(self):
         self.vetos = {}


### PR DESCRIPTION
Make vetos optional, since there has been a persistent memory issue when querying vetos with gwpy.