### PR TITLE
Add `html` file as output to plots Task

### DIFF
--- a/aframe/tasks/plots/sv.py
+++ b/aframe/tasks/plots/sv.py
@@ -46,8 +46,9 @@ class SensitiveVolume(AframeSingularityTask):
         return reqs
 
     def output(self):
-        path = os.path.join(self.output_dir, "sensitive_volume.h5")
-        return law.LocalFileTarget(path)
+        data = os.path.join(self.output_dir, "sensitive_volume.h5")
+        plot = os.path.join(self.output_dir, "sensitive_volume.html")
+        return [law.LocalFileTarget(data), law.LocalFileTarget(plot)]
 
     def run(self):
         from pathlib import Path


### PR DESCRIPTION
Was causing plots task to not run when only the h5 file was written, but the task broke before html was made