### PR TITLE
Prevented passing task-specific condor parameters to required tasks

### DIFF
--- a/aframe/tasks/data/condor/base.py
+++ b/aframe/tasks/data/condor/base.py
@@ -30,6 +30,7 @@ class LDGCondorWorkflow(htcondor.HTCondorWorkflow):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.exclude_params_req |= self.exclude_params_branch
         self.htcondor_log_dir.touch()
         self.htcondor_output_directory().touch()
         law.config.update(


### PR DESCRIPTION
We set `poll_interval` and `parallel_jobs` in `Infer`, which were getting passed to `FetchTest`. This stops that from happening.