### PR TITLE
Use `cache` argument in `fetch_open_data`

### DIFF
--- a/projects/data/data/fetch/fetch.py
+++ b/projects/data/data/fetch/fetch.py
@@ -56,6 +56,7 @@ def fetch(
             end=end,
             verbose=verbose,
             nproc=nproc,
+            cache=True,
         )
         data.update(open_data_ts_dict)
 

--- a/projects/data/data/fetch/fetch.py
+++ b/projects/data/data/fetch/fetch.py
@@ -23,6 +23,7 @@ def fetch(
     nproc: int = 3,
     verbose: bool = True,
     allow_tape: bool = True,
+    cache: bool = True,
 ) -> TimeSeriesDict:
     """
     Simple wrapper to annotate and simplify
@@ -56,7 +57,7 @@ def fetch(
             end=end,
             verbose=verbose,
             nproc=nproc,
-            cache=True,
+            cache=cache,
         )
         data.update(open_data_ts_dict)
 


### PR DESCRIPTION
Takes advantage of `cache` argument in `fetch_open_data` which should help speed up querying if done multiple times