### PR TITLE
Updated training and testing waveform params

### DIFF
--- a/aframe/pipelines/sandbox/configs/base.cfg
+++ b/aframe/pipelines/sandbox/configs/base.cfg
@@ -103,7 +103,7 @@ request_cpus = 1
 
 [luigi_TestingWaveforms]
 workflow = htcondor
-num_signals = 1350000
+num_signals = 500_000
 shifts = &::luigi_base::shifts
 spacing = 16
 buffer = 16

--- a/projects/train/config.yaml
+++ b/projects/train/config.yaml
@@ -29,7 +29,7 @@ model:
     learning_rate: 0.000585
     pct_lr_ramp: 0.115
     # early stop
-    patience: 50
+    patience: null
 data:
   class_path: train.data.supervised.TimeDomainSupervisedAframeDataset
   init_args:
@@ -39,7 +39,7 @@ data:
 
     # preprocessing args
     batch_size: 384
-    batches_per_epoch: 800
+    batches_per_epoch: 3700
     chunk_size: 10000
     chunks_per_epoch: 10
     # kernel_length:


### PR DESCRIPTION
Set training patience to `null`, increased `batches_per_epoch` to 3700, and decreased the number of testing waveforms to 500,000 to avoid the memory issue that sometimes pops up.