### PR TITLE
Support for `TorchScript` exporting of `aframe` model

### DIFF
--- a/.github/workflows/project-build-test.yaml
+++ b/.github/workflows/project-build-test.yaml
@@ -56,8 +56,10 @@ jobs:
           - project: 'workflow' # Fixed the exclusion key
     steps:
     -
-      name: delete huge unnecessary tools folder
-      run: rm -rf /opt/hostedtoolcache 
+      name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
     -
       name: Checkout repository
       uses: actions/checkout@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "hermes"]
-	path = hermes
-	url = git@github.com:ML4GW/hermes.git
 [submodule "amplfi"]
 	path = amplfi
 	url = git@github.com:ML4GW/amplfi.git

--- a/aframe/base.py
+++ b/aframe/base.py
@@ -21,6 +21,15 @@ S3_ENV_VARS = [
     "AWS_EXTERNAL_ENDPOINT_URL",
 ]
 
+# env vars that correspond to directories
+# that should be mounted so that users
+# can point to one anothers directories
+AFRAME_DATA_DIRS = [
+    "AFRAME_TRAIN_DATA_DIR",
+    "AFRAME_TEST_DATA_DIR",
+    "AFRAME_TRAIN_RUN_DIR",
+]
+
 
 class AframeParameters(law.Task):
     dev = luigi.BoolParameter(
@@ -85,6 +94,14 @@ class AframeSandbox(singularity.SingularitySandbox):
         # bind aws directory that contains s3 credentials
         aws_dir = os.path.expanduser("~/.aws/")
         volumes[aws_dir] = aws_dir
+
+        # bind AFRAME env var data directories
+        # so users can point to other users directories
+        # set any environment variables
+        for path in AFRAME_DATA_DIRS:
+            value = os.getenv(path)
+            if value is not None:
+                volumes[value] = value
         return volumes
 
     def _get_env(self):

--- a/aframe/base.py
+++ b/aframe/base.py
@@ -97,7 +97,6 @@ class AframeSandbox(singularity.SingularitySandbox):
 
         # bind AFRAME env var data directories
         # so users can point to other users directories
-        # set any environment variables
         for path in AFRAME_DATA_DIRS:
             value = os.getenv(path)
             if value is not None:

--- a/aframe/pipelines/sandbox/configs/base.cfg
+++ b/aframe/pipelines/sandbox/configs/base.cfg
@@ -158,7 +158,7 @@ rate_per_gpu = 70
 # triton args
 model_name = aframe-stream
 model_version = -1
-triton_image = hermes/tritonserver:22.12
+triton_image = hermes/tritonserver:23.01
 sequence_id = 1001
 
 request_memory = 6G

--- a/aframe/pipelines/sandbox/configs/base.cfg
+++ b/aframe/pipelines/sandbox/configs/base.cfg
@@ -130,9 +130,7 @@ fduration = &::luigi_base::fduration
 kernel_length = &::luigi_base::kernel_length
 inference_sampling_rate = &::luigi_base::inference_sampling_rate
 sample_rate = &::luigi_base::sample_rate
-
-# TODO: resolve enum platform parsing error
-# platform = luigi.Parameter(default="TENSORRT")
+platform = TENSORRT
 ifos = &::luigi_base::ifos
 batch_size = &::luigi_base::inference_batch_size
 psd_length = &::luigi_base::inference_psd_length

--- a/aframe/pipelines/sandbox/configs/bbh.cfg
+++ b/aframe/pipelines/sandbox/configs/bbh.cfg
@@ -22,6 +22,7 @@ buffer = 16
 [luigi_Train]
 ifos = &::luigi_base::ifos
 kernel_length = &::luigi_base::kernel_length
+sample_rate = &::luigi_base::sample_rate
 highpass = &::luigi_base::highpass
 fduration = &::luigi_base::fduration
 seed = &::luigi_base::seed

--- a/aframe/pipelines/sandbox/configs/bns.cfg
+++ b/aframe/pipelines/sandbox/configs/bns.cfg
@@ -31,6 +31,7 @@ buffer = 90
 [luigi_Train]
 ifos = &::luigi_base::ifos
 kernel_length = &::luigi_base::kernel_length
+sample_rate = &::luigi_base::sample_rate
 highpass = &::luigi_base::highpass
 fduration = &::luigi_base::fduration
 seed = &::luigi_base::seed

--- a/aframe/pipelines/sandbox/configs/review.cfg
+++ b/aframe/pipelines/sandbox/configs/review.cfg
@@ -86,9 +86,7 @@ fduration = &::luigi_base::fduration
 kernel_length = &::luigi_base::kernel_length
 inference_sampling_rate = &::luigi_base::inference_sampling_rate
 sample_rate = &::luigi_base::sample_rate
-
-# TODO: resolve enum platform parsing error
-# platform = luigi.Parameter(default="TENSORRT")
+platform = TENSORRT
 ifos = &::luigi_base::ifos
 batch_size = &::luigi_base::inference_batch_size
 psd_length = &::luigi_base::inference_psd_length

--- a/aframe/pipelines/sandbox/configs/review.cfg
+++ b/aframe/pipelines/sandbox/configs/review.cfg
@@ -115,7 +115,7 @@ zero_lag = true
 # triton args
 model_name = aframe-stream
 model_version = -1
-triton_image = hermes/tritonserver:22.12
+triton_image = hermes/tritonserver:23.01
 sequence_id = 1001
 
 request_memory = 6G

--- a/aframe/pipelines/sandbox/configs/tune.cfg
+++ b/aframe/pipelines/sandbox/configs/tune.cfg
@@ -13,6 +13,7 @@ inherit = $AFRAME_REPO/aframe/pipelines/sandbox/configs/base.cfg
 config = $AFRAME_REPO/projects/train/config.yaml
 ifos = &::luigi_base::ifos
 kernel_length = &::luigi_base::kernel_length
+sample_rate = &::luigi_base::sample_rate
 highpass = &::luigi_base::highpass
 fduration = &::luigi_base::fduration
 seed = &::luigi_base::seed

--- a/aframe/tasks/export/export.py
+++ b/aframe/tasks/export/export.py
@@ -43,7 +43,7 @@ class ExportLocal(AframeSingularityTask):
         self.repository_directory.mkdir(exist_ok=True, parents=True)
 
     def output(self):
-        return ModelRepositoryTarget(self.repository_directory)
+        return ModelRepositoryTarget(self.repository_directory, self.platform)
 
     def requires(self):
         return self.train_task.req(self)
@@ -61,8 +61,8 @@ class ExportLocal(AframeSingularityTask):
 
         from export.main import export
 
-        # Convert string to Platform enum
-        platform = Platform(self.platform)
+        # convert string to Platform enum
+        platform = Platform[self.platform]
 
         if not self.fftlength:
             self.fftlength = None

--- a/aframe/tasks/export/export.py
+++ b/aframe/tasks/export/export.py
@@ -23,8 +23,8 @@ class ExportParams(law.Task):
     batch_size = luigi.IntParameter()
     psd_length = luigi.FloatParameter()
     highpass = luigi.FloatParameter()
-    q = luigi.OptionalFloatParameter(default=None)
-    fftlength = luigi.FloatParameter(default=0)
+    q = luigi.OptionalFloatParameter(default="")
+    fftlength = luigi.OptionalFloatParameter(default="")
     ifos = luigi.ListParameter()
     repository_directory = PathParameter(
         default=paths().results_dir / "model_repo"
@@ -63,9 +63,6 @@ class ExportLocal(AframeSingularityTask):
 
         # convert string to Platform enum
         platform = Platform[self.platform]
-
-        if not self.fftlength:
-            self.fftlength = None
 
         # Assuming a convention for batch file/model file
         # names and locations

--- a/aframe/tasks/export/export.py
+++ b/aframe/tasks/export/export.py
@@ -30,8 +30,10 @@ class ExportParams(law.Task):
         default=paths().results_dir / "model_repo"
     )
     train_task = luigi.TaskParameter()
-    # TODO: resolve enum platform parsing error
-    # platform = luigi.Parameter(default="TENSORRT")
+    platform = luigi.Parameter(
+        default="TENSORRT",
+        description="Platform to use for exporting model for inference",
+    )
 
 
 @inherits(ExportParams)
@@ -55,7 +57,12 @@ class ExportLocal(AframeSingularityTask):
         return len(self.ifos)
 
     def run(self):
+        from hermes.quiver import Platform
+
         from export.main import export
+
+        # Convert string to Platform enum
+        platform = Platform(self.platform)
 
         if not self.fftlength:
             self.fftlength = None
@@ -83,7 +90,6 @@ class ExportLocal(AframeSingularityTask):
             self.streams_per_gpu,
             self.aframe_instances,
             self.preproc_instances,
-            # self.platform,
+            platform,
             clean=self.clean,
-            # verbose=self.verbose,
         )

--- a/aframe/tasks/export/target.py
+++ b/aframe/tasks/export/target.py
@@ -2,16 +2,22 @@ import os
 
 import luigi
 
+conventions = {
+    "TENSORRT": "model.plan",
+    "TORCHSCRIPT": "model.pt",
+}
+
 
 class ModelRepositoryTarget(luigi.Target):
     """
     Target for checking the existence of an aframe model repository
     """
 
-    def __init__(self, path, version: int = -1):
+    def __init__(self, path, platform: str, version: int = -1):
         super().__init__()
         self.path = path
         self.version = version
+        self.platform = platform
 
     def get_versions(self):
         versions = []
@@ -45,7 +51,10 @@ class ModelRepositoryTarget(luigi.Target):
 
         # define the structure of the model repo
         structure = {
-            "aframe": ["config.pbtxt", (version, ["model.plan"])],
+            "aframe": [
+                "config.pbtxt",
+                (version, [conventions[self.platform]]),
+            ],
             "aframe-stream": ["config.pbtxt", (version, ["model.empty"])],
             "preprocessor": ["config.pbtxt", (version, ["model.pt"])],
             "snapshotter": ["config.pbtxt", (version, ["model.onnx"])],

--- a/aframe/tasks/train/base.py
+++ b/aframe/tasks/train/base.py
@@ -30,6 +30,9 @@ class TrainBaseParameters(law.Task):
         description="Length of the kernel in seconds "
         "the neural-network will analyze"
     )
+    sample_rate = luigi.FloatParameter(
+        description="Sample rate of the data in Hz"
+    )
     highpass = luigi.FloatParameter(
         description="Highpass frequency in Hz to apply during whitening"
     )
@@ -97,6 +100,7 @@ class TrainBase(law.Task):
         # (e.g. model architecture config, training hyperparams,
         # logging, profiling, etc.) should be specified in the
         # train projects config.yaml file.
+        args.append("--data.sample_rate=" + str(self.sample_rate))
         args.append("--data.kernel_length=" + str(self.kernel_length))
         args.append("--data.fduration=" + str(self.fduration))
         args.append("--data.fftlength=" + str(self.fftlength))

--- a/aframe/tasks/train/base.py
+++ b/aframe/tasks/train/base.py
@@ -36,8 +36,9 @@ class TrainBaseParameters(law.Task):
     highpass = luigi.FloatParameter(
         description="Highpass frequency in Hz to apply during whitening"
     )
-    fftlength = luigi.FloatParameter(
-        description="Duration in seconds of data used for FFT calculation"
+    fftlength = luigi.OptionalFloatParameter(
+        description="Duration in seconds of data used for FFT calculation",
+        default="",
     )
     q = luigi.OptionalFloatParameter(
         default=None, description="Value of Q used for Q-transform"
@@ -100,10 +101,11 @@ class TrainBase(law.Task):
         # (e.g. model architecture config, training hyperparams,
         # logging, profiling, etc.) should be specified in the
         # train projects config.yaml file.
+        fftlength = self.fftlength or "null"
         args.append("--data.sample_rate=" + str(self.sample_rate))
         args.append("--data.kernel_length=" + str(self.kernel_length))
         args.append("--data.fduration=" + str(self.fduration))
-        args.append("--data.fftlength=" + str(self.fftlength))
+        args.append("--data.fftlength=" + str(fftlength))
         args.append("--data.highpass=" + str(self.highpass))
         if self.q is not None:
             args.append("--data.q=" + str(self.q))

--- a/aframe/tasks/train/train.py
+++ b/aframe/tasks/train/train.py
@@ -44,7 +44,7 @@ class TrainLocal(TrainBase, AframeSingularityTask):
             args.append("--trainer.strategy=ddp")
         cmd = [sys.executable, "-m", "train"] + args
         cmd_str = shlex.join(cmd)
-        logger.debug(f"Executing command {cmd_str}")
+        logger.info(f"Executing command {cmd_str}")
         stream_command(cmd)
 
     def output(self):

--- a/aframe/tasks/train/train.py
+++ b/aframe/tasks/train/train.py
@@ -82,7 +82,6 @@ class TrainRemote(KubernetesJobTask, RemoteTrainBase):
             raise ValueError(
                 "data_dir must be an s3 path for remote training tasks"
             )
-        authenticate()
 
     @property
     def default_image(self):
@@ -276,6 +275,7 @@ class TrainRemote(KubernetesJobTask, RemoteTrainBase):
         return spec
 
     def run(self):
+        authenticate()
         if not self.s3_secret.exists():
             self.s3_secret.create()
 
@@ -284,12 +284,14 @@ class TrainRemote(KubernetesJobTask, RemoteTrainBase):
         super().run()
 
     def on_failure(self, exc):
+        authenticate()
         self.s3_secret.delete()
         if self.use_init_container:
             self.git_secret().delete()
         super().on_failure(exc)
 
     def on_success(self):
+        authenticate()
         self.s3_secret.delete()
         if self.use_init_container:
             self.git_secret().delete()

--- a/libs/architectures/architectures/supervised.py
+++ b/libs/architectures/architectures/supervised.py
@@ -134,6 +134,7 @@ class SupervisedS4Model(S4Model, SupervisedArchitecture):
     def __init__(
         self,
         num_ifos: int,
+        length: int,
         d_output: int = 1,
         d_model: int = 128,
         n_layers: int = 4,
@@ -144,6 +145,7 @@ class SupervisedS4Model(S4Model, SupervisedArchitecture):
         lr: Optional[float] = None,
     ) -> None:
         super().__init__(
+            length=length,
             d_input=num_ifos,
             d_output=d_output,
             d_model=d_model,

--- a/libs/architectures/architectures/supervised.py
+++ b/libs/architectures/architectures/supervised.py
@@ -26,6 +26,8 @@ class SupervisedTimeDomainResNet(ResNet1D, SupervisedArchitecture):
     def __init__(
         self,
         num_ifos: int,
+        sample_rate: float,
+        kernel_length: float,
         layers: list[int],
         kernel_size: int = 3,
         zero_init_residual: bool = False,
@@ -51,6 +53,8 @@ class SupervisedFrequencyDomainResNet(ResNet1D, SupervisedArchitecture):
     def __init__(
         self,
         num_ifos: int,
+        sample_rate: float,
+        kernel_length: float,
         layers: list[int],
         kernel_size: int = 3,
         zero_init_residual: bool = False,
@@ -76,6 +80,8 @@ class SupervisedTimeDomainXylophone(Xylophone, SupervisedArchitecture):
     def __init__(
         self,
         num_ifos: int,
+        sample_rate: float,
+        kernel_length: float,
         norm_layer: Optional[NormLayer] = None,
     ):
         super().__init__(
@@ -89,6 +95,8 @@ class SupervisedTimeDomainWaveNet(WaveNet, SupervisedArchitecture):
     def __init__(
         self,
         num_ifos: int,
+        sample_rate: float,
+        kernel_length: float,
         res_channels: int,
         layers_per_block: int,
         num_blocks: int,
@@ -109,6 +117,8 @@ class SupervisedSpectrogramDomainResNet(ResNet2D, SupervisedArchitecture):
     def __init__(
         self,
         num_ifos: int,
+        sample_rate: float,
+        kernel_length: float,
         layers: list[int],
         kernel_size: int = 3,
         zero_init_residual: bool = False,
@@ -134,7 +144,8 @@ class SupervisedS4Model(S4Model, SupervisedArchitecture):
     def __init__(
         self,
         num_ifos: int,
-        length: int,
+        sample_rate: float,
+        kernel_length: float,
         d_output: int = 1,
         d_model: int = 128,
         n_layers: int = 4,
@@ -144,6 +155,7 @@ class SupervisedS4Model(S4Model, SupervisedArchitecture):
         dt_max: float = 0.1,
         lr: Optional[float] = None,
     ) -> None:
+        length = int(kernel_length * sample_rate)
         super().__init__(
             length=length,
             d_input=num_ifos,

--- a/libs/utils/poetry.lock
+++ b/libs/utils/poetry.lock
@@ -1443,4 +1443,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.13"
-content-hash = "b679738ef9d876a62eabf10e7e5d73c7c6ca8d6f7550307482a75ac6e38e89b4"
+content-hash = "bb632e30d3a43d616e7bd0322a39334b7fbe0886752c3b3842271a6cf514cf12"

--- a/libs/utils/pyproject.toml
+++ b/libs/utils/pyproject.toml
@@ -12,7 +12,7 @@ s3fs = "^2024"
 
 # make preprocessing modules here for use in
 # both validation and inference export
-ml4gw = "^0.5"
+ml4gw = ">=0.5.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1723,13 +1723,13 @@ lxml = ["lxml"]
 
 [[package]]
 name = "httpcore"
-version = "1.0.5"
+version = "1.0.6"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "httpcore-1.0.5-py3-none-any.whl", hash = "sha256:421f18bac248b25d310f3cacd198d55b8e6125c107797b609ff9b7a6ba7991b5"},
-    {file = "httpcore-1.0.5.tar.gz", hash = "sha256:34a38e2f9291467ee3b44e89dd52615370e152954ba21721378a87b2960f7a61"},
+    {file = "httpcore-1.0.6-py3-none-any.whl", hash = "sha256:27b59625743b85577a8c0e10e55b50b5368a4f2cfe8cc7bcfa9cf00829c2682f"},
+    {file = "httpcore-1.0.6.tar.gz", hash = "sha256:73f6dbd6eb8c21bbf7ef8efad555481853f5f6acdeaff1edb0694289269ee17f"},
 ]
 
 [package.dependencies]
@@ -1740,7 +1740,7 @@ h11 = ">=0.13,<0.15"
 asyncio = ["anyio (>=4.0,<5.0)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
-trio = ["trio (>=0.22.0,<0.26.0)"]
+trio = ["trio (>=0.22.0,<1.0)"]
 
 [[package]]
 name = "httpx"
@@ -2632,28 +2632,28 @@ torchaudio = ">=2.0,<3.0"
 
 [[package]]
 name = "ml4gw-hermes"
-version = "0.0.1"
+version = "0.2.0"
 description = "Inference-as-a-Service deployment made simple"
 optional = false
-python-versions = ">=3.9,<3.13"
-files = []
-develop = true
+python-versions = "<3.13,>=3.9"
+files = [
+    {file = "ml4gw_hermes-0.2.0-py3-none-any.whl", hash = "sha256:30e32135e44d7babed8f4636268a11c47b811a6250b3bc9dc8c066d929d1a388"},
+    {file = "ml4gw_hermes-0.2.0.tar.gz", hash = "sha256:e254f2b3dff8676e75d35c0eb0e7f41d76feb3a74614ab154493ac2f344294c5"},
+]
 
 [package.dependencies]
-protobuf = "^3.17"
-requests = "^2.26.0"
-tblib = "^1.7"
-tritonclient = {version = "^2.22", extras = ["all"]}
+numpy = ">=1.22,<2.0"
+protobuf = ">=3.17,<4.0"
+requests = ">=2.26.0,<3.0.0"
+spython = ">=0.2,<0.3"
+tblib = ">=1.7,<2.0"
+tritonclient = {version = ">=2.22,<3.0", extras = ["all"]}
 
 [package.extras]
 gcs = ["google-cloud-storage (>=1.38,<2.0)"]
 tensorflow = ["tensorflow (<2.17)", "tf-keras (>=2.16,<2.17)"]
 tensorrt = ["nvidia-tensorrt (>=8.0,<9.0)"]
 torch = ["onnx (>=1.15.0,<2.0.0)", "torch (>=2.0,<3.0)", "urllib3 (>=1.26,<2.0)"]
-
-[package.source]
-type = "directory"
-url = "hermes"
 
 [[package]]
 name = "more-itertools"
@@ -3189,14 +3189,14 @@ files = [
 
 [[package]]
 name = "nvidia-nvjitlink-cu12"
-version = "12.6.68"
+version = "12.6.77"
 description = "Nvidia JIT LTO Library"
 optional = false
 python-versions = ">=3"
 files = [
-    {file = "nvidia_nvjitlink_cu12-12.6.68-py3-none-manylinux2014_aarch64.whl", hash = "sha256:b3fd0779845f68b92063ab1393abab1ed0a23412fc520df79a8190d098b5cd6b"},
-    {file = "nvidia_nvjitlink_cu12-12.6.68-py3-none-manylinux2014_x86_64.whl", hash = "sha256:125a6c2a44e96386dda634e13d944e60b07a0402d391a070e8fb4104b34ea1ab"},
-    {file = "nvidia_nvjitlink_cu12-12.6.68-py3-none-win_amd64.whl", hash = "sha256:a55744c98d70317c5e23db14866a8cc2b733f7324509e941fc96276f9f37801d"},
+    {file = "nvidia_nvjitlink_cu12-12.6.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:3bf10d85bb1801e9c894c6e197e44dd137d2a0a9e43f8450e9ad13f2df0dd52d"},
+    {file = "nvidia_nvjitlink_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:9ae346d16203ae4ea513be416495167a0101d33d2d14935aa9c1829a3fb45142"},
+    {file = "nvidia_nvjitlink_cu12-12.6.77-py3-none-win_amd64.whl", hash = "sha256:410718cd44962bed862a31dd0318620f6f9a8b28a6291967bcfcb446a6516771"},
 ]
 
 [[package]]
@@ -4363,6 +4363,17 @@ cryptography = ">=2.0"
 jeepney = ">=0.6"
 
 [[package]]
+name = "semver"
+version = "3.0.2"
+description = "Python helper for Semantic Versioning (https://semver.org)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "semver-3.0.2-py3-none-any.whl", hash = "sha256:b1ea4686fe70b981f85359eda33199d60c53964284e0cfb4977d243e37cf4bf4"},
+    {file = "semver-3.0.2.tar.gz", hash = "sha256:6253adb39c70f6e51afed2fa7152bcd414c411286088fb4b9effb133885ab4cc"},
+]
+
+[[package]]
 name = "send2trash"
 version = "1.8.3"
 description = "Send file to trash natively under Mac OS X, Windows and Linux"
@@ -4444,14 +4455,16 @@ files = [
 
 [[package]]
 name = "spython"
-version = "0.3.14"
+version = "0.2.14"
 description = "Command line python tool for working with singularity."
 optional = false
 python-versions = "*"
 files = [
-    {file = "spython-0.3.14-py3-none-any.whl", hash = "sha256:72968583e498bc2a51f9acd0ed6bc0d7d1f7ccd491feaba5e2f7d944bc51da3a"},
-    {file = "spython-0.3.14.tar.gz", hash = "sha256:8ad53ef034395cfa2d8a710cc1c3638e4475e5bbc6a2842d317db8013c2e4188"},
+    {file = "spython-0.2.14.tar.gz", hash = "sha256:49e22fbbdebe456b27ca17d30061489db8e0f95e62be3623267a23b85e3ce0f0"},
 ]
+
+[package.dependencies]
+semver = ">=2.8.1"
 
 [[package]]
 name = "stack-data"
@@ -4556,13 +4569,13 @@ test = ["pytest", "ruff"]
 
 [[package]]
 name = "tomli"
-version = "2.0.1"
+version = "2.0.2"
 description = "A lil' TOML parser"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+    {file = "tomli-2.0.2-py3-none-any.whl", hash = "sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38"},
+    {file = "tomli-2.0.2.tar.gz", hash = "sha256:d46d457a85337051c36524bc5349dd91b1877838e2979ac5ced3e710ed8a60ed"},
 ]
 
 [[package]]
@@ -4775,13 +4788,13 @@ test = ["mypy", "pytest", "typing-extensions"]
 
 [[package]]
 name = "types-python-dateutil"
-version = "2.9.0.20240906"
+version = "2.9.0.20241003"
 description = "Typing stubs for python-dateutil"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "types-python-dateutil-2.9.0.20240906.tar.gz", hash = "sha256:9706c3b68284c25adffc47319ecc7947e5bb86b3773f843c73906fd598bc176e"},
-    {file = "types_python_dateutil-2.9.0.20240906-py3-none-any.whl", hash = "sha256:27c8cc2d058ccb14946eebcaaa503088f4f6dbc4fb6093d3d456a49aef2753f6"},
+    {file = "types-python-dateutil-2.9.0.20241003.tar.gz", hash = "sha256:58cb85449b2a56d6684e41aeefb4c4280631246a0da1a719bdbe6f3fb0317446"},
+    {file = "types_python_dateutil-2.9.0.20241003-py3-none-any.whl", hash = "sha256:250e1d8e80e7bbc3a6c99b907762711d1a1cdd00e978ad39cb5940f6f0a87f3d"},
 ]
 
 [[package]]
@@ -5202,4 +5215,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "6015d063fe97b11f52960961abfdb70dd51760bf6495b790fca9f66c9ea9087b"
+content-hash = "226b4b3778338ed9c1e0c03e3370e53f0dbca758a291a27bf190e82a153491ef"

--- a/projects/data/apptainer.def
+++ b/projects/data/apptainer.def
@@ -8,7 +8,6 @@ Stage: build
 ../../libs/ledger /opt/aframe/libs/ledger
 ../../libs/priors /opt/aframe/libs/priors
 ../../aframe /opt/aframe/aframe
-../../hermes /opt/aframe/hermes
 ../../pyproject.toml /opt/aframe/pyproject.toml
 
 %post

--- a/projects/data/poetry.lock
+++ b/projects/data/poetry.lock
@@ -15,11 +15,11 @@ cloudpathlib = "^0.18.1"
 kr8s = "^0.10.0"
 law = {git = "https://github.com/riga/law.git", branch = "master"}
 luigi = "^3.0"
-ml4gw-hermes = {path = "hermes", develop = true, extras = ["serve"]}
+ml4gw-hermes = ">=0.2.0"
 numpy = "^1.26.4"
 psutil = "^5.9.8"
 pykube-ng = {version = "^23.6.0", extras = ["oidc"]}
-spython = "^0.3.13"
+spython = "^0.2"
 utils = {path = "libs/utils", develop = true}
 
 [package.source]
@@ -1819,13 +1819,14 @@ name = "ledger"
 version = "0.1.0"
 description = "Objects for storing and manipulating aframe data"
 optional = false
-python-versions = ">=3.8,<3.13"
+python-versions = ">=3.9,<3.13"
 files = []
 develop = true
 
 [package.dependencies]
 bilby = "^2.2.2"
 h5py = "^3.10.0"
+numpy = "^1.26"
 
 [package.source]
 type = "directory"
@@ -2015,28 +2016,28 @@ torchaudio = ">=2.0,<3.0"
 
 [[package]]
 name = "ml4gw-hermes"
-version = "0.0.1"
+version = "0.2.0"
 description = "Inference-as-a-Service deployment made simple"
 optional = false
-python-versions = ">=3.9,<3.13"
-files = []
-develop = true
+python-versions = "<3.13,>=3.9"
+files = [
+    {file = "ml4gw_hermes-0.2.0-py3-none-any.whl", hash = "sha256:30e32135e44d7babed8f4636268a11c47b811a6250b3bc9dc8c066d929d1a388"},
+    {file = "ml4gw_hermes-0.2.0.tar.gz", hash = "sha256:e254f2b3dff8676e75d35c0eb0e7f41d76feb3a74614ab154493ac2f344294c5"},
+]
 
 [package.dependencies]
-protobuf = "^3.17"
-requests = "^2.26.0"
-tblib = "^1.7"
-tritonclient = {version = "^2.22", extras = ["all"]}
+numpy = ">=1.22,<2.0"
+protobuf = ">=3.17,<4.0"
+requests = ">=2.26.0,<3.0.0"
+spython = ">=0.2,<0.3"
+tblib = ">=1.7,<2.0"
+tritonclient = {version = ">=2.22,<3.0", extras = ["all"]}
 
 [package.extras]
 gcs = ["google-cloud-storage (>=1.38,<2.0)"]
 tensorflow = ["tensorflow (<2.17)", "tf-keras (>=2.16,<2.17)"]
 tensorrt = ["nvidia-tensorrt (>=8.0,<9.0)"]
 torch = ["onnx (>=1.15.0,<2.0.0)", "torch (>=2.0,<3.0)", "urllib3 (>=1.26,<2.0)"]
-
-[package.source]
-type = "directory"
-url = "../../hermes"
 
 [[package]]
 name = "mpmath"
@@ -2603,6 +2604,7 @@ develop = true
 [package.dependencies]
 astropy = "^5.0"
 bilby = "^2.2.2"
+numpy = "^1.26.4"
 
 [package.source]
 type = "directory"
@@ -3116,6 +3118,17 @@ doc = ["jupyterlite-pyodide-kernel", "jupyterlite-sphinx (>=0.12.0)", "jupytext"
 test = ["array-api-strict", "asv", "gmpy2", "hypothesis (>=6.30)", "mpmath", "pooch", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
 
 [[package]]
+name = "semver"
+version = "3.0.2"
+description = "Python helper for Semantic Versioning (https://semver.org)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "semver-3.0.2-py3-none-any.whl", hash = "sha256:b1ea4686fe70b981f85359eda33199d60c53964284e0cfb4977d243e37cf4bf4"},
+    {file = "semver-3.0.2.tar.gz", hash = "sha256:6253adb39c70f6e51afed2fa7152bcd414c411286088fb4b9effb133885ab4cc"},
+]
+
+[[package]]
 name = "setuptools"
 version = "75.1.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -3159,14 +3172,16 @@ files = [
 
 [[package]]
 name = "spython"
-version = "0.3.14"
+version = "0.2.14"
 description = "Command line python tool for working with singularity."
 optional = false
 python-versions = "*"
 files = [
-    {file = "spython-0.3.14-py3-none-any.whl", hash = "sha256:72968583e498bc2a51f9acd0ed6bc0d7d1f7ccd491feaba5e2f7d944bc51da3a"},
-    {file = "spython-0.3.14.tar.gz", hash = "sha256:8ad53ef034395cfa2d8a710cc1c3638e4475e5bbc6a2842d317db8013c2e4188"},
+    {file = "spython-0.2.14.tar.gz", hash = "sha256:49e22fbbdebe456b27ca17d30061489db8e0f95e62be3623267a23b85e3ce0f0"},
 ]
+
+[package.dependencies]
+semver = ">=2.8.1"
 
 [[package]]
 name = "sympy"
@@ -3508,7 +3523,7 @@ develop = true
 
 [package.dependencies]
 h5py = "^3.6"
-ml4gw = "^0.5"
+ml4gw = ">=0.5.1"
 s3fs = "^2024"
 
 [package.source]

--- a/projects/export/apptainer.def
+++ b/projects/export/apptainer.def
@@ -7,7 +7,6 @@ Stage: build
 ../../libs/utils /opt/aframe/libs/utils
 ../../aframe /opt/aframe/aframe
 ../../pyproject.toml /opt/aframe/pyproject.toml
-../../hermes /opt/aframe/hermes
 
 %post
 # installing the local package editably via pip

--- a/projects/export/export/snapshotter.py
+++ b/projects/export/export/snapshotter.py
@@ -98,10 +98,12 @@ def add_streaming_input_preprocessor(
 
     input_shape = streaming_model.outputs["strain"].shape
     preproc_model.export_version(
-        preprocessor, input_shapes=[input_shape], output_names=None
+        preprocessor,
+        input_shapes={"strain": input_shape},
+        output_names=["whitened"],
     )
     ensemble.pipe(
         streaming_model.outputs["strain"],
-        preproc_model.inputs["INPUT__0"],
+        preproc_model.inputs["strain"],
     )
-    return preproc_model.outputs["OUTPUT__0"]
+    return preproc_model.outputs["whitened"]

--- a/projects/export/poetry.lock
+++ b/projects/export/poetry.lock
@@ -2478,16 +2478,16 @@ test = ["pytest", "tornado (>=4.5)", "typeguard"]
 
 [[package]]
 name = "tensorrt"
-version = "8.5.1.7"
+version = "8.5.2.2"
 description = "A high performance deep learning inference library"
 optional = false
 python-versions = "*"
 files = [
-    {file = "tensorrt-8.5.1.7-cp310-none-manylinux_2_17_x86_64.whl", hash = "sha256:f21c1ace958fbef1b8427ed182f5ef5710f2affa10f9c5adbd320a01ee8072c3"},
-    {file = "tensorrt-8.5.1.7-cp36-none-manylinux_2_17_x86_64.whl", hash = "sha256:188f398a22eae3c9ae91698455f3ae336aefd152be716b04c20f4eee24a31745"},
-    {file = "tensorrt-8.5.1.7-cp37-none-manylinux_2_17_x86_64.whl", hash = "sha256:584aadd90a1fe449c44950307c159cc00295890d3804854b3fdf996c4d86bc13"},
-    {file = "tensorrt-8.5.1.7-cp38-none-manylinux_2_17_x86_64.whl", hash = "sha256:83486b65f2580983f5231f8f6721a8b6eb7a265889920a39f80a983313c5e37d"},
-    {file = "tensorrt-8.5.1.7-cp39-none-manylinux_2_17_x86_64.whl", hash = "sha256:c707f6a8e91279047f1a515779ee80961821641e5a264fa54b7dd20072235fcd"},
+    {file = "tensorrt-8.5.2.2-cp310-none-manylinux_2_17_x86_64.whl", hash = "sha256:ea36754388ac2e995c36bccff97c60690256da3d090f03672e0cadbac12226cc"},
+    {file = "tensorrt-8.5.2.2-cp36-none-manylinux_2_17_x86_64.whl", hash = "sha256:d55ee06a173257d58b896a335553a6c3ce25b66b5650ee5ad9d0a6ce5ceb91ac"},
+    {file = "tensorrt-8.5.2.2-cp37-none-manylinux_2_17_x86_64.whl", hash = "sha256:8393c66569bd3c62e351a21edee91b50d7f1b9d0d73d7c886d735613e2630ace"},
+    {file = "tensorrt-8.5.2.2-cp38-none-manylinux_2_17_x86_64.whl", hash = "sha256:24d9468d031d6bd07bcd267428991bfadfa7c717779fce6ef14e2ea99cf52cd4"},
+    {file = "tensorrt-8.5.2.2-cp39-none-manylinux_2_17_x86_64.whl", hash = "sha256:cf681245eaa7807c7ff067963b3d57f1dc78b5bdc66e26d3a1186725e1904f1a"},
 ]
 
 [package.dependencies]
@@ -2718,7 +2718,7 @@ develop = true
 
 [package.dependencies]
 h5py = "^3.6"
-ml4gw = "^0.5"
+ml4gw = ">=0.5.1"
 s3fs = "^2024"
 
 [package.source]
@@ -2981,4 +2981,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "2f248f613f530f238abcb1a41c35bc4d6a26d6eebfef56f1dcd2b61b7147130e"
+content-hash = "37b41fe65fb82486c500d22333a109bcf87ae647e78a01c08e42e76b82694310"

--- a/projects/export/poetry.lock
+++ b/projects/export/poetry.lock
@@ -15,11 +15,11 @@ cloudpathlib = "^0.18.1"
 kr8s = "^0.10.0"
 law = {git = "https://github.com/riga/law.git", branch = "master"}
 luigi = "^3.0"
-ml4gw-hermes = {path = "hermes", develop = true, extras = ["serve"]}
+ml4gw-hermes = ">=0.2.0"
 numpy = "^1.26.4"
 psutil = "^5.9.8"
 pykube-ng = {version = "^23.6.0", extras = ["oidc"]}
-spython = "^0.3.13"
+spython = "^0.2"
 utils = {path = "libs/utils", develop = true}
 
 [package.source]
@@ -1160,13 +1160,13 @@ numpy = ">=1.19.3"
 
 [[package]]
 name = "httpcore"
-version = "1.0.5"
+version = "1.0.6"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "httpcore-1.0.5-py3-none-any.whl", hash = "sha256:421f18bac248b25d310f3cacd198d55b8e6125c107797b609ff9b7a6ba7991b5"},
-    {file = "httpcore-1.0.5.tar.gz", hash = "sha256:34a38e2f9291467ee3b44e89dd52615370e152954ba21721378a87b2960f7a61"},
+    {file = "httpcore-1.0.6-py3-none-any.whl", hash = "sha256:27b59625743b85577a8c0e10e55b50b5368a4f2cfe8cc7bcfa9cf00829c2682f"},
+    {file = "httpcore-1.0.6.tar.gz", hash = "sha256:73f6dbd6eb8c21bbf7ef8efad555481853f5f6acdeaff1edb0694289269ee17f"},
 ]
 
 [package.dependencies]
@@ -1177,7 +1177,7 @@ h11 = ">=0.13,<0.15"
 asyncio = ["anyio (>=4.0,<5.0)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
-trio = ["trio (>=0.22.0,<0.26.0)"]
+trio = ["trio (>=0.22.0,<1.0)"]
 
 [[package]]
 name = "httpx"
@@ -1463,31 +1463,31 @@ torchaudio = ">=2.0,<3.0"
 
 [[package]]
 name = "ml4gw-hermes"
-version = "0.0.1"
+version = "0.2.0"
 description = "Inference-as-a-Service deployment made simple"
 optional = false
-python-versions = ">=3.9,<3.13"
-files = []
-develop = true
+python-versions = "<3.13,>=3.9"
+files = [
+    {file = "ml4gw_hermes-0.2.0-py3-none-any.whl", hash = "sha256:30e32135e44d7babed8f4636268a11c47b811a6250b3bc9dc8c066d929d1a388"},
+    {file = "ml4gw_hermes-0.2.0.tar.gz", hash = "sha256:e254f2b3dff8676e75d35c0eb0e7f41d76feb3a74614ab154493ac2f344294c5"},
+]
 
 [package.dependencies]
-onnx = {version = "^1.15.0", optional = true}
-protobuf = "^3.17"
-requests = "^2.26.0"
-tblib = "^1.7"
-torch = {version = "^2.0", optional = true}
-tritonclient = {version = "^2.22", extras = ["all"]}
-urllib3 = "^1.26"
+numpy = ">=1.22,<2.0"
+onnx = {version = ">=1.15.0,<2.0.0", optional = true, markers = "extra == \"torch\""}
+protobuf = ">=3.17,<4.0"
+requests = ">=2.26.0,<3.0.0"
+spython = ">=0.2,<0.3"
+tblib = ">=1.7,<2.0"
+torch = {version = ">=2.0,<3.0", optional = true, markers = "extra == \"torch\""}
+tritonclient = {version = ">=2.22,<3.0", extras = ["all"]}
+urllib3 = {version = ">=1.26,<2.0", optional = true, markers = "extra == \"torch\""}
 
 [package.extras]
 gcs = ["google-cloud-storage (>=1.38,<2.0)"]
 tensorflow = ["tensorflow (<2.17)", "tf-keras (>=2.16,<2.17)"]
 tensorrt = ["nvidia-tensorrt (>=8.0,<9.0)"]
 torch = ["onnx (>=1.15.0,<2.0.0)", "torch (>=2.0,<3.0)", "urllib3 (>=1.26,<2.0)"]
-
-[package.source]
-type = "directory"
-url = "../../hermes"
 
 [[package]]
 name = "mpmath"
@@ -1849,14 +1849,14 @@ files = [
 
 [[package]]
 name = "nvidia-nvjitlink-cu12"
-version = "12.6.68"
+version = "12.6.77"
 description = "Nvidia JIT LTO Library"
 optional = false
 python-versions = ">=3"
 files = [
-    {file = "nvidia_nvjitlink_cu12-12.6.68-py3-none-manylinux2014_aarch64.whl", hash = "sha256:b3fd0779845f68b92063ab1393abab1ed0a23412fc520df79a8190d098b5cd6b"},
-    {file = "nvidia_nvjitlink_cu12-12.6.68-py3-none-manylinux2014_x86_64.whl", hash = "sha256:125a6c2a44e96386dda634e13d944e60b07a0402d391a070e8fb4104b34ea1ab"},
-    {file = "nvidia_nvjitlink_cu12-12.6.68-py3-none-win_amd64.whl", hash = "sha256:a55744c98d70317c5e23db14866a8cc2b733f7324509e941fc96276f9f37801d"},
+    {file = "nvidia_nvjitlink_cu12-12.6.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:3bf10d85bb1801e9c894c6e197e44dd137d2a0a9e43f8450e9ad13f2df0dd52d"},
+    {file = "nvidia_nvjitlink_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:9ae346d16203ae4ea513be416495167a0101d33d2d14935aa9c1829a3fb45142"},
+    {file = "nvidia_nvjitlink_cu12-12.6.77-py3-none-win_amd64.whl", hash = "sha256:410718cd44962bed862a31dd0318620f6f9a8b28a6291967bcfcb446a6516771"},
 ]
 
 [[package]]
@@ -1888,37 +1888,37 @@ signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
 name = "onnx"
-version = "1.16.2"
+version = "1.17.0"
 description = "Open Neural Network Exchange"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "onnx-1.16.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:ab0a1aa6b0470020ea3636afdce3e2a67f856fefe4be8c73b20371b07fcde69c"},
-    {file = "onnx-1.16.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a449122a49534bb9c2b6f16c8493b606ef0accda6b9dbf0c513ca4b31ebe8b38"},
-    {file = "onnx-1.16.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec6a425e59291fff430da4a884aa07a1d0cbb5dcd22cc78f6cf4ba5adb9f3367"},
-    {file = "onnx-1.16.2-cp310-cp310-win32.whl", hash = "sha256:55fbaf38acd4cd8fdd0b4f36871fb596b075518d3e981acc893f2ab887d1891a"},
-    {file = "onnx-1.16.2-cp310-cp310-win_amd64.whl", hash = "sha256:4e496d301756e0a22fd2bdfac24b861c7b1ddbdd9ce7677b2a252c00c4c8f2a7"},
-    {file = "onnx-1.16.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:859b41574243c9bfd0abce03c15c78a1f270cc03c7f99629b984daf7adfa5003"},
-    {file = "onnx-1.16.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:39a57d196fe5d73861e70d9625674e6caf8ca13c5e9c740462cf530a07cd2e1c"},
-    {file = "onnx-1.16.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b98aa9733bd4b781eb931d33b4078ff2837e7d68062460726d6dd011f332bd4"},
-    {file = "onnx-1.16.2-cp311-cp311-win32.whl", hash = "sha256:e9f018b2e172efeea8c2473a51a825652767726374145d7cfdebdc7a27446fdd"},
-    {file = "onnx-1.16.2-cp311-cp311-win_amd64.whl", hash = "sha256:e66e4512a30df8916db5cf84f47d47b3250b9ab9a98d9cffe142c98c54598ba0"},
-    {file = "onnx-1.16.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:bfdb8c2eb4c92f55626376e00993db8fcc753da4b80babf28d99636af8dbae6b"},
-    {file = "onnx-1.16.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b77a6c138f284dfc9b06fa370768aa4fd167efc49ff740e2158dd02eedde8d0"},
-    {file = "onnx-1.16.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca12e47965e590b63f31681c8c563c75449a04178f27eac1ff64bad314314fb3"},
-    {file = "onnx-1.16.2-cp312-cp312-win32.whl", hash = "sha256:324fe3551e91ffd74b43dbcf1d48e96579f4c1be2ff1224591ecd3ec6daa6139"},
-    {file = "onnx-1.16.2-cp312-cp312-win_amd64.whl", hash = "sha256:080b19b0bd2b5536b4c61812464fe495758d6c9cfed3fdd3f20516e616212bee"},
-    {file = "onnx-1.16.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:c42a5db2db36fc46d3a93ab6aeff0f11abe10a4a16a85f2aad8879a58a898ee5"},
-    {file = "onnx-1.16.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9635437ffe51cc71343f3067bc548a068bd287ac690f65a9f6223ea9dca441bf"},
-    {file = "onnx-1.16.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e9e22be82c3447ba6d2fe851973a736a7013e97b398e8beb7a25fd2ad4df219e"},
-    {file = "onnx-1.16.2-cp38-cp38-win32.whl", hash = "sha256:e16012431643c66124eba0089acdad0df71d5c9d4e6bec4721999f9eecab72b7"},
-    {file = "onnx-1.16.2-cp38-cp38-win_amd64.whl", hash = "sha256:42231a467e5be2974d426b410987073ed85bee34af7b50c93ab221a8696b0cfd"},
-    {file = "onnx-1.16.2-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:e79edba750ae06059d82d8ff8129a6488a7e692cd23cd7fe010f7ec7d6a14bad"},
-    {file = "onnx-1.16.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d192db8501103fede9c1725861e65ed41efb65da1ce915ba969aae40073eb94"},
-    {file = "onnx-1.16.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da01d4a3bd7a0d0ee5084f65441fc9ca38450fc18835b7f9d5da5b9e7ca8b85d"},
-    {file = "onnx-1.16.2-cp39-cp39-win32.whl", hash = "sha256:0b765b09bdb01fa2338ea52483aa3d9c75e249f85446f0d9ad1dc5bd2b149082"},
-    {file = "onnx-1.16.2-cp39-cp39-win_amd64.whl", hash = "sha256:bfee781a59919e797f4dae380e63a0390ec01ce5c337a1459b992aac2f49a3c2"},
-    {file = "onnx-1.16.2.tar.gz", hash = "sha256:b33a282b038813c4b69e73ea65c2909768e8dd6cc10619b70632335daf094646"},
+    {file = "onnx-1.17.0-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:38b5df0eb22012198cdcee527cc5f917f09cce1f88a69248aaca22bd78a7f023"},
+    {file = "onnx-1.17.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d545335cb49d4d8c47cc803d3a805deb7ad5d9094dc67657d66e568610a36d7d"},
+    {file = "onnx-1.17.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3193a3672fc60f1a18c0f4c93ac81b761bc72fd8a6c2035fa79ff5969f07713e"},
+    {file = "onnx-1.17.0-cp310-cp310-win32.whl", hash = "sha256:0141c2ce806c474b667b7e4499164227ef594584da432fd5613ec17c1855e311"},
+    {file = "onnx-1.17.0-cp310-cp310-win_amd64.whl", hash = "sha256:dfd777d95c158437fda6b34758f0877d15b89cbe9ff45affbedc519b35345cf9"},
+    {file = "onnx-1.17.0-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:d6fc3a03fc0129b8b6ac03f03bc894431ffd77c7d79ec023d0afd667b4d35869"},
+    {file = "onnx-1.17.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f01a4b63d4e1d8ec3e2f069e7b798b2955810aa434f7361f01bc8ca08d69cce4"},
+    {file = "onnx-1.17.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a183c6178be001bf398260e5ac2c927dc43e7746e8638d6c05c20e321f8c949"},
+    {file = "onnx-1.17.0-cp311-cp311-win32.whl", hash = "sha256:081ec43a8b950171767d99075b6b92553901fa429d4bc5eb3ad66b36ef5dbe3a"},
+    {file = "onnx-1.17.0-cp311-cp311-win_amd64.whl", hash = "sha256:95c03e38671785036bb704c30cd2e150825f6ab4763df3a4f1d249da48525957"},
+    {file = "onnx-1.17.0-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:0e906e6a83437de05f8139ea7eaf366bf287f44ae5cc44b2850a30e296421f2f"},
+    {file = "onnx-1.17.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d955ba2939878a520a97614bcf2e79c1df71b29203e8ced478fa78c9a9c63c2"},
+    {file = "onnx-1.17.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f3fb5cc4e2898ac5312a7dc03a65133dd2abf9a5e520e69afb880a7251ec97a"},
+    {file = "onnx-1.17.0-cp312-cp312-win32.whl", hash = "sha256:317870fca3349d19325a4b7d1b5628f6de3811e9710b1e3665c68b073d0e68d7"},
+    {file = "onnx-1.17.0-cp312-cp312-win_amd64.whl", hash = "sha256:659b8232d627a5460d74fd3c96947ae83db6d03f035ac633e20cd69cfa029227"},
+    {file = "onnx-1.17.0-cp38-cp38-macosx_12_0_universal2.whl", hash = "sha256:23b8d56a9df492cdba0eb07b60beea027d32ff5e4e5fe271804eda635bed384f"},
+    {file = "onnx-1.17.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ecf2b617fd9a39b831abea2df795e17bac705992a35a98e1f0363f005c4a5247"},
+    {file = "onnx-1.17.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea5023a8dcdadbb23fd0ed0179ce64c1f6b05f5b5c34f2909b4e927589ebd0e4"},
+    {file = "onnx-1.17.0-cp38-cp38-win32.whl", hash = "sha256:f0e437f8f2f0c36f629e9743d28cf266312baa90be6a899f405f78f2d4cb2e1d"},
+    {file = "onnx-1.17.0-cp38-cp38-win_amd64.whl", hash = "sha256:e4673276b558b5b572b960b7f9ef9214dce9305673683eb289bb97a7df379a4b"},
+    {file = "onnx-1.17.0-cp39-cp39-macosx_12_0_universal2.whl", hash = "sha256:67e1c59034d89fff43b5301b6178222e54156eadd6ab4cd78ddc34b2f6274a66"},
+    {file = "onnx-1.17.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e19fd064b297f7773b4c1150f9ce6213e6d7d041d7a9201c0d348041009cdcd"},
+    {file = "onnx-1.17.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8167295f576055158a966161f8ef327cb491c06ede96cc23392be6022071b6ed"},
+    {file = "onnx-1.17.0-cp39-cp39-win32.whl", hash = "sha256:76884fe3e0258c911c749d7d09667fb173365fd27ee66fcedaf9fa039210fd13"},
+    {file = "onnx-1.17.0-cp39-cp39-win_amd64.whl", hash = "sha256:5ca7a0894a86d028d509cdcf99ed1864e19bfe5727b44322c11691d834a1c546"},
+    {file = "onnx-1.17.0.tar.gz", hash = "sha256:48ca1a91ff73c1d5e3ea2eef20ae5d0e709bb8a2355ed798ffc2169753013fd3"},
 ]
 
 [package.dependencies]
@@ -1926,7 +1926,7 @@ numpy = ">=1.20"
 protobuf = ">=3.20.2"
 
 [package.extras]
-reference = ["google-re2", "pillow"]
+reference = ["Pillow", "google-re2"]
 
 [[package]]
 name = "packaging"
@@ -2368,6 +2368,17 @@ botocore = ">=1.33.2,<2.0a.0"
 crt = ["botocore[crt] (>=1.33.2,<2.0a.0)"]
 
 [[package]]
+name = "semver"
+version = "3.0.2"
+description = "Python helper for Semantic Versioning (https://semver.org)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "semver-3.0.2-py3-none-any.whl", hash = "sha256:b1ea4686fe70b981f85359eda33199d60c53964284e0cfb4977d243e37cf4bf4"},
+    {file = "semver-3.0.2.tar.gz", hash = "sha256:6253adb39c70f6e51afed2fa7152bcd414c411286088fb4b9effb133885ab4cc"},
+]
+
+[[package]]
 name = "setuptools"
 version = "75.1.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -2411,14 +2422,16 @@ files = [
 
 [[package]]
 name = "spython"
-version = "0.3.14"
+version = "0.2.14"
 description = "Command line python tool for working with singularity."
 optional = false
 python-versions = "*"
 files = [
-    {file = "spython-0.3.14-py3-none-any.whl", hash = "sha256:72968583e498bc2a51f9acd0ed6bc0d7d1f7ccd491feaba5e2f7d944bc51da3a"},
-    {file = "spython-0.3.14.tar.gz", hash = "sha256:8ad53ef034395cfa2d8a710cc1c3638e4475e5bbc6a2842d317db8013c2e4188"},
+    {file = "spython-0.2.14.tar.gz", hash = "sha256:49e22fbbdebe456b27ca17d30061489db8e0f95e62be3623267a23b85e3ce0f0"},
 ]
+
+[package.dependencies]
+semver = ">=2.8.1"
 
 [[package]]
 name = "sympy"
@@ -2487,13 +2500,13 @@ numpy = ["numpy"]
 
 [[package]]
 name = "tomli"
-version = "2.0.1"
+version = "2.0.2"
 description = "A lil' TOML parser"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+    {file = "tomli-2.0.2-py3-none-any.whl", hash = "sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38"},
+    {file = "tomli-2.0.2.tar.gz", hash = "sha256:d46d457a85337051c36524bc5349dd91b1877838e2979ac5ced3e710ed8a60ed"},
 ]
 
 [[package]]
@@ -2968,4 +2981,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "a533ef2140da36a7075f2953f51e5eb218bb66c9ece9da4e2f6f7290ff1c1b15"
+content-hash = "2f248f613f530f238abcb1a41c35bc4d6a26d6eebfef56f1dcd2b61b7147130e"

--- a/projects/export/pyproject.toml
+++ b/projects/export/pyproject.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 description = "Export aframe for IaaS inference"
 authors = ["Ethan Jacob Marx <ethan.marx@ligo.org>"]
 license = "MIT"
-#readme = "README.md"
 
 [tool.poetry.scripts]
 export-model = "export.main:export"
@@ -25,7 +24,7 @@ fsspec = {version = "^2024", extras=["s3"]}
 
 
 # local deps
-ml4gw-hermes = {path = "../../hermes", develop = true, extras = ["torch"]}
+ml4gw-hermes = {version = ">=0.2.0", extras = ["torch"]}
 aframe = {path = "../../", develop = true}
 utils = {path = "../../libs/utils", develop = true}
 jsonargparse = "^4.27.1"

--- a/projects/export/pyproject.toml
+++ b/projects/export/pyproject.toml
@@ -30,7 +30,7 @@ utils = {path = "../../libs/utils", develop = true}
 jsonargparse = "^4.27.1"
 
 nvidia-cudnn-cu11 = "8.9.6.50"
-tensorrt = "8.5.1.7"
+tensorrt = "8.5.2.2"
 # workaround for: https://github.com/python-poetry/poetry-plugin-export/issues/183
 urllib3 = ">=1.25.4,<1.27"
 

--- a/projects/infer/apptainer.def
+++ b/projects/infer/apptainer.def
@@ -8,10 +8,9 @@ Stage: build
 # accidentally get created in this repo
 . /opt/aframe/projects/infer
 ../../libs/utils /opt/aframe/libs/utils
+../../libs/ledger /opt/aframe/libs/ledger
 ../../aframe /opt/aframe/aframe
 ../../pyproject.toml /opt/aframe/pyproject.toml
-../../hermes /opt/aframe/hermes
-../../libs/ledger /opt/aframe/libs/ledger
 
 %post
 # installing the local package editably via pip

--- a/projects/infer/apptainer.def
+++ b/projects/infer/apptainer.def
@@ -23,6 +23,7 @@ Stage: build
 # we'll hard pin it to the value we need.
 # TODO: there's got to be a better solution here
 python -m pip install poetry==1.7.1
+pip install poetry-plugin-export
 cd /opt/aframe/projects/infer
 poetry export -o requirements.txt --without-hashes \
     && sed -i 's|\(.*\) @ file://|-e |' requirements.txt

--- a/projects/infer/poetry.lock
+++ b/projects/infer/poetry.lock
@@ -4946,7 +4946,7 @@ develop = true
 
 [package.dependencies]
 h5py = "^3.6"
-ml4gw = "^0.5"
+ml4gw = ">=0.5.1"
 s3fs = "^2024"
 
 [package.source]

--- a/projects/infer/poetry.lock
+++ b/projects/infer/poetry.lock
@@ -15,11 +15,11 @@ cloudpathlib = "^0.18.1"
 kr8s = "^0.10.0"
 law = {git = "https://github.com/riga/law.git", branch = "master"}
 luigi = "^3.0"
-ml4gw-hermes = {path = "hermes", develop = true, extras = ["serve"]}
+ml4gw-hermes = ">=0.2.0"
 numpy = "^1.26.4"
 psutil = "^5.9.8"
 pykube-ng = {version = "^23.6.0", extras = ["oidc"]}
-spython = "^0.3.13"
+spython = "^0.2"
 utils = {path = "libs/utils", develop = true}
 
 [package.source]
@@ -803,20 +803,6 @@ files = [
     {file = "charset_normalizer-3.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d"},
     {file = "charset_normalizer-3.3.2-py3-none-any.whl", hash = "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc"},
 ]
-
-[[package]]
-name = "click"
-version = "8.1.7"
-description = "Composable command line interface toolkit"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
-    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
-]
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cloudpathlib"
@@ -1741,13 +1727,13 @@ numpy = ">=1.19.3"
 
 [[package]]
 name = "httpcore"
-version = "1.0.5"
+version = "1.0.6"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "httpcore-1.0.5-py3-none-any.whl", hash = "sha256:421f18bac248b25d310f3cacd198d55b8e6125c107797b609ff9b7a6ba7991b5"},
-    {file = "httpcore-1.0.5.tar.gz", hash = "sha256:34a38e2f9291467ee3b44e89dd52615370e152954ba21721378a87b2960f7a61"},
+    {file = "httpcore-1.0.6-py3-none-any.whl", hash = "sha256:27b59625743b85577a8c0e10e55b50b5368a4f2cfe8cc7bcfa9cf00829c2682f"},
+    {file = "httpcore-1.0.6.tar.gz", hash = "sha256:73f6dbd6eb8c21bbf7ef8efad555481853f5f6acdeaff1edb0694289269ee17f"},
 ]
 
 [package.dependencies]
@@ -1758,7 +1744,7 @@ h11 = ">=0.13,<0.15"
 asyncio = ["anyio (>=4.0,<5.0)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
-trio = ["trio (>=0.22.0,<0.26.0)"]
+trio = ["trio (>=0.22.0,<1.0)"]
 
 [[package]]
 name = "httpx"
@@ -2550,13 +2536,14 @@ name = "ledger"
 version = "0.1.0"
 description = "Objects for storing and manipulating aframe data"
 optional = false
-python-versions = ">=3.8,<3.13"
+python-versions = ">=3.9,<3.13"
 files = []
 develop = true
 
 [package.dependencies]
 bilby = "^2.2.2"
 h5py = "^3.10.0"
+numpy = "^1.26"
 
 [package.source]
 type = "directory"
@@ -2771,31 +2758,31 @@ torchaudio = ">=2.0,<3.0"
 
 [[package]]
 name = "ml4gw-hermes"
-version = "0.0.1"
+version = "0.2.0"
 description = "Inference-as-a-Service deployment made simple"
 optional = false
-python-versions = ">=3.9,<3.13"
-files = []
-develop = true
+python-versions = "<3.13,>=3.9"
+files = [
+    {file = "ml4gw_hermes-0.2.0-py3-none-any.whl", hash = "sha256:30e32135e44d7babed8f4636268a11c47b811a6250b3bc9dc8c066d929d1a388"},
+    {file = "ml4gw_hermes-0.2.0.tar.gz", hash = "sha256:e254f2b3dff8676e75d35c0eb0e7f41d76feb3a74614ab154493ac2f344294c5"},
+]
 
 [package.dependencies]
-onnx = {version = "^1.15.0", optional = true}
-protobuf = "^3.17"
-requests = "^2.26.0"
-tblib = "^1.7"
-torch = {version = "^2.0", optional = true}
-tritonclient = {version = "^2.22", extras = ["all"]}
-urllib3 = "^1.26"
+numpy = ">=1.22,<2.0"
+onnx = {version = ">=1.15.0,<2.0.0", optional = true, markers = "extra == \"torch\""}
+protobuf = ">=3.17,<4.0"
+requests = ">=2.26.0,<3.0.0"
+spython = ">=0.2,<0.3"
+tblib = ">=1.7,<2.0"
+torch = {version = ">=2.0,<3.0", optional = true, markers = "extra == \"torch\""}
+tritonclient = {version = ">=2.22,<3.0", extras = ["all"]}
+urllib3 = {version = ">=1.26,<2.0", optional = true, markers = "extra == \"torch\""}
 
 [package.extras]
 gcs = ["google-cloud-storage (>=1.38,<2.0)"]
 tensorflow = ["tensorflow (<2.17)", "tf-keras (>=2.16,<2.17)"]
 tensorrt = ["nvidia-tensorrt (>=8.0,<9.0)"]
 torch = ["onnx (>=1.15.0,<2.0.0)", "torch (>=2.0,<3.0)", "urllib3 (>=1.26,<2.0)"]
-
-[package.source]
-type = "directory"
-url = "../../hermes"
 
 [[package]]
 name = "mpmath"
@@ -2813,79 +2800,6 @@ develop = ["codecov", "pycodestyle", "pytest (>=4.6)", "pytest-cov", "wheel"]
 docs = ["sphinx"]
 gmpy = ["gmpy2 (>=2.1.0a4)"]
 tests = ["pytest (>=4.6)"]
-
-[[package]]
-name = "msgpack"
-version = "1.1.0"
-description = "MessagePack serializer"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "msgpack-1.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7ad442d527a7e358a469faf43fda45aaf4ac3249c8310a82f0ccff9164e5dccd"},
-    {file = "msgpack-1.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:74bed8f63f8f14d75eec75cf3d04ad581da6b914001b474a5d3cd3372c8cc27d"},
-    {file = "msgpack-1.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:914571a2a5b4e7606997e169f64ce53a8b1e06f2cf2c3a7273aa106236d43dd5"},
-    {file = "msgpack-1.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c921af52214dcbb75e6bdf6a661b23c3e6417f00c603dd2070bccb5c3ef499f5"},
-    {file = "msgpack-1.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d8ce0b22b890be5d252de90d0e0d119f363012027cf256185fc3d474c44b1b9e"},
-    {file = "msgpack-1.1.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:73322a6cc57fcee3c0c57c4463d828e9428275fb85a27aa2aa1a92fdc42afd7b"},
-    {file = "msgpack-1.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e1f3c3d21f7cf67bcf2da8e494d30a75e4cf60041d98b3f79875afb5b96f3a3f"},
-    {file = "msgpack-1.1.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:64fc9068d701233effd61b19efb1485587560b66fe57b3e50d29c5d78e7fef68"},
-    {file = "msgpack-1.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:42f754515e0f683f9c79210a5d1cad631ec3d06cea5172214d2176a42e67e19b"},
-    {file = "msgpack-1.1.0-cp310-cp310-win32.whl", hash = "sha256:3df7e6b05571b3814361e8464f9304c42d2196808e0119f55d0d3e62cd5ea044"},
-    {file = "msgpack-1.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:685ec345eefc757a7c8af44a3032734a739f8c45d1b0ac45efc5d8977aa4720f"},
-    {file = "msgpack-1.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3d364a55082fb2a7416f6c63ae383fbd903adb5a6cf78c5b96cc6316dc1cedc7"},
-    {file = "msgpack-1.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:79ec007767b9b56860e0372085f8504db5d06bd6a327a335449508bbee9648fa"},
-    {file = "msgpack-1.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6ad622bf7756d5a497d5b6836e7fc3752e2dd6f4c648e24b1803f6048596f701"},
-    {file = "msgpack-1.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e59bca908d9ca0de3dc8684f21ebf9a690fe47b6be93236eb40b99af28b6ea6"},
-    {file = "msgpack-1.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e1da8f11a3dd397f0a32c76165cf0c4eb95b31013a94f6ecc0b280c05c91b59"},
-    {file = "msgpack-1.1.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:452aff037287acb1d70a804ffd022b21fa2bb7c46bee884dbc864cc9024128a0"},
-    {file = "msgpack-1.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8da4bf6d54ceed70e8861f833f83ce0814a2b72102e890cbdfe4b34764cdd66e"},
-    {file = "msgpack-1.1.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:41c991beebf175faf352fb940bf2af9ad1fb77fd25f38d9142053914947cdbf6"},
-    {file = "msgpack-1.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a52a1f3a5af7ba1c9ace055b659189f6c669cf3657095b50f9602af3a3ba0fe5"},
-    {file = "msgpack-1.1.0-cp311-cp311-win32.whl", hash = "sha256:58638690ebd0a06427c5fe1a227bb6b8b9fdc2bd07701bec13c2335c82131a88"},
-    {file = "msgpack-1.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:fd2906780f25c8ed5d7b323379f6138524ba793428db5d0e9d226d3fa6aa1788"},
-    {file = "msgpack-1.1.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:d46cf9e3705ea9485687aa4001a76e44748b609d260af21c4ceea7f2212a501d"},
-    {file = "msgpack-1.1.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:5dbad74103df937e1325cc4bfeaf57713be0b4f15e1c2da43ccdd836393e2ea2"},
-    {file = "msgpack-1.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:58dfc47f8b102da61e8949708b3eafc3504509a5728f8b4ddef84bd9e16ad420"},
-    {file = "msgpack-1.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4676e5be1b472909b2ee6356ff425ebedf5142427842aa06b4dfd5117d1ca8a2"},
-    {file = "msgpack-1.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17fb65dd0bec285907f68b15734a993ad3fc94332b5bb21b0435846228de1f39"},
-    {file = "msgpack-1.1.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a51abd48c6d8ac89e0cfd4fe177c61481aca2d5e7ba42044fd218cfd8ea9899f"},
-    {file = "msgpack-1.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2137773500afa5494a61b1208619e3871f75f27b03bcfca7b3a7023284140247"},
-    {file = "msgpack-1.1.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:398b713459fea610861c8a7b62a6fec1882759f308ae0795b5413ff6a160cf3c"},
-    {file = "msgpack-1.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:06f5fd2f6bb2a7914922d935d3b8bb4a7fff3a9a91cfce6d06c13bc42bec975b"},
-    {file = "msgpack-1.1.0-cp312-cp312-win32.whl", hash = "sha256:ad33e8400e4ec17ba782f7b9cf868977d867ed784a1f5f2ab46e7ba53b6e1e1b"},
-    {file = "msgpack-1.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:115a7af8ee9e8cddc10f87636767857e7e3717b7a2e97379dc2054712693e90f"},
-    {file = "msgpack-1.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:071603e2f0771c45ad9bc65719291c568d4edf120b44eb36324dcb02a13bfddf"},
-    {file = "msgpack-1.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0f92a83b84e7c0749e3f12821949d79485971f087604178026085f60ce109330"},
-    {file = "msgpack-1.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4a1964df7b81285d00a84da4e70cb1383f2e665e0f1f2a7027e683956d04b734"},
-    {file = "msgpack-1.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:59caf6a4ed0d164055ccff8fe31eddc0ebc07cf7326a2aaa0dbf7a4001cd823e"},
-    {file = "msgpack-1.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0907e1a7119b337971a689153665764adc34e89175f9a34793307d9def08e6ca"},
-    {file = "msgpack-1.1.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:65553c9b6da8166e819a6aa90ad15288599b340f91d18f60b2061f402b9a4915"},
-    {file = "msgpack-1.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7a946a8992941fea80ed4beae6bff74ffd7ee129a90b4dd5cf9c476a30e9708d"},
-    {file = "msgpack-1.1.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4b51405e36e075193bc051315dbf29168d6141ae2500ba8cd80a522964e31434"},
-    {file = "msgpack-1.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b4c01941fd2ff87c2a934ee6055bda4ed353a7846b8d4f341c428109e9fcde8c"},
-    {file = "msgpack-1.1.0-cp313-cp313-win32.whl", hash = "sha256:7c9a35ce2c2573bada929e0b7b3576de647b0defbd25f5139dcdaba0ae35a4cc"},
-    {file = "msgpack-1.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:bce7d9e614a04d0883af0b3d4d501171fbfca038f12c77fa838d9f198147a23f"},
-    {file = "msgpack-1.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c40ffa9a15d74e05ba1fe2681ea33b9caffd886675412612d93ab17b58ea2fec"},
-    {file = "msgpack-1.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1ba6136e650898082d9d5a5217d5906d1e138024f836ff48691784bbe1adf96"},
-    {file = "msgpack-1.1.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e0856a2b7e8dcb874be44fea031d22e5b3a19121be92a1e098f46068a11b0870"},
-    {file = "msgpack-1.1.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:471e27a5787a2e3f974ba023f9e265a8c7cfd373632247deb225617e3100a3c7"},
-    {file = "msgpack-1.1.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:646afc8102935a388ffc3914b336d22d1c2d6209c773f3eb5dd4d6d3b6f8c1cb"},
-    {file = "msgpack-1.1.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:13599f8829cfbe0158f6456374e9eea9f44eee08076291771d8ae93eda56607f"},
-    {file = "msgpack-1.1.0-cp38-cp38-win32.whl", hash = "sha256:8a84efb768fb968381e525eeeb3d92857e4985aacc39f3c47ffd00eb4509315b"},
-    {file = "msgpack-1.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:879a7b7b0ad82481c52d3c7eb99bf6f0645dbdec5134a4bddbd16f3506947feb"},
-    {file = "msgpack-1.1.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:53258eeb7a80fc46f62fd59c876957a2d0e15e6449a9e71842b6d24419d88ca1"},
-    {file = "msgpack-1.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7e7b853bbc44fb03fbdba34feb4bd414322180135e2cb5164f20ce1c9795ee48"},
-    {file = "msgpack-1.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f3e9b4936df53b970513eac1758f3882c88658a220b58dcc1e39606dccaaf01c"},
-    {file = "msgpack-1.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46c34e99110762a76e3911fc923222472c9d681f1094096ac4102c18319e6468"},
-    {file = "msgpack-1.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a706d1e74dd3dea05cb54580d9bd8b2880e9264856ce5068027eed09680aa74"},
-    {file = "msgpack-1.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:534480ee5690ab3cbed89d4c8971a5c631b69a8c0883ecfea96c19118510c846"},
-    {file = "msgpack-1.1.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:8cf9e8c3a2153934a23ac160cc4cba0ec035f6867c8013cc6077a79823370346"},
-    {file = "msgpack-1.1.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:3180065ec2abbe13a4ad37688b61b99d7f9e012a535b930e0e683ad6bc30155b"},
-    {file = "msgpack-1.1.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c5a91481a3cc573ac8c0d9aace09345d989dc4a0202b7fcb312c88c26d4e71a8"},
-    {file = "msgpack-1.1.0-cp39-cp39-win32.whl", hash = "sha256:f80bc7d47f76089633763f952e67f8214cb7b3ee6bfa489b3cb6a84cfac114cd"},
-    {file = "msgpack-1.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:4d1b7ff2d6146e16e8bd665ac726a89c74163ef8cd39fa8c1087d4e52d3a2325"},
-    {file = "msgpack-1.1.0.tar.gz", hash = "sha256:dd432ccc2c72b914e4cb77afce64aab761c1137cc698be3984eee260bcb2896e"},
-]
 
 [[package]]
 name = "multidict"
@@ -3309,14 +3223,14 @@ files = [
 
 [[package]]
 name = "nvidia-nvjitlink-cu12"
-version = "12.6.68"
+version = "12.6.77"
 description = "Nvidia JIT LTO Library"
 optional = false
 python-versions = ">=3"
 files = [
-    {file = "nvidia_nvjitlink_cu12-12.6.68-py3-none-manylinux2014_aarch64.whl", hash = "sha256:b3fd0779845f68b92063ab1393abab1ed0a23412fc520df79a8190d098b5cd6b"},
-    {file = "nvidia_nvjitlink_cu12-12.6.68-py3-none-manylinux2014_x86_64.whl", hash = "sha256:125a6c2a44e96386dda634e13d944e60b07a0402d391a070e8fb4104b34ea1ab"},
-    {file = "nvidia_nvjitlink_cu12-12.6.68-py3-none-win_amd64.whl", hash = "sha256:a55744c98d70317c5e23db14866a8cc2b733f7324509e941fc96276f9f37801d"},
+    {file = "nvidia_nvjitlink_cu12-12.6.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:3bf10d85bb1801e9c894c6e197e44dd137d2a0a9e43f8450e9ad13f2df0dd52d"},
+    {file = "nvidia_nvjitlink_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:9ae346d16203ae4ea513be416495167a0101d33d2d14935aa9c1829a3fb45142"},
+    {file = "nvidia_nvjitlink_cu12-12.6.77-py3-none-win_amd64.whl", hash = "sha256:410718cd44962bed862a31dd0318620f6f9a8b28a6291967bcfcb446a6516771"},
 ]
 
 [[package]]
@@ -3348,37 +3262,37 @@ signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
 name = "onnx"
-version = "1.16.2"
+version = "1.17.0"
 description = "Open Neural Network Exchange"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "onnx-1.16.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:ab0a1aa6b0470020ea3636afdce3e2a67f856fefe4be8c73b20371b07fcde69c"},
-    {file = "onnx-1.16.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a449122a49534bb9c2b6f16c8493b606ef0accda6b9dbf0c513ca4b31ebe8b38"},
-    {file = "onnx-1.16.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec6a425e59291fff430da4a884aa07a1d0cbb5dcd22cc78f6cf4ba5adb9f3367"},
-    {file = "onnx-1.16.2-cp310-cp310-win32.whl", hash = "sha256:55fbaf38acd4cd8fdd0b4f36871fb596b075518d3e981acc893f2ab887d1891a"},
-    {file = "onnx-1.16.2-cp310-cp310-win_amd64.whl", hash = "sha256:4e496d301756e0a22fd2bdfac24b861c7b1ddbdd9ce7677b2a252c00c4c8f2a7"},
-    {file = "onnx-1.16.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:859b41574243c9bfd0abce03c15c78a1f270cc03c7f99629b984daf7adfa5003"},
-    {file = "onnx-1.16.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:39a57d196fe5d73861e70d9625674e6caf8ca13c5e9c740462cf530a07cd2e1c"},
-    {file = "onnx-1.16.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b98aa9733bd4b781eb931d33b4078ff2837e7d68062460726d6dd011f332bd4"},
-    {file = "onnx-1.16.2-cp311-cp311-win32.whl", hash = "sha256:e9f018b2e172efeea8c2473a51a825652767726374145d7cfdebdc7a27446fdd"},
-    {file = "onnx-1.16.2-cp311-cp311-win_amd64.whl", hash = "sha256:e66e4512a30df8916db5cf84f47d47b3250b9ab9a98d9cffe142c98c54598ba0"},
-    {file = "onnx-1.16.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:bfdb8c2eb4c92f55626376e00993db8fcc753da4b80babf28d99636af8dbae6b"},
-    {file = "onnx-1.16.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b77a6c138f284dfc9b06fa370768aa4fd167efc49ff740e2158dd02eedde8d0"},
-    {file = "onnx-1.16.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca12e47965e590b63f31681c8c563c75449a04178f27eac1ff64bad314314fb3"},
-    {file = "onnx-1.16.2-cp312-cp312-win32.whl", hash = "sha256:324fe3551e91ffd74b43dbcf1d48e96579f4c1be2ff1224591ecd3ec6daa6139"},
-    {file = "onnx-1.16.2-cp312-cp312-win_amd64.whl", hash = "sha256:080b19b0bd2b5536b4c61812464fe495758d6c9cfed3fdd3f20516e616212bee"},
-    {file = "onnx-1.16.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:c42a5db2db36fc46d3a93ab6aeff0f11abe10a4a16a85f2aad8879a58a898ee5"},
-    {file = "onnx-1.16.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9635437ffe51cc71343f3067bc548a068bd287ac690f65a9f6223ea9dca441bf"},
-    {file = "onnx-1.16.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e9e22be82c3447ba6d2fe851973a736a7013e97b398e8beb7a25fd2ad4df219e"},
-    {file = "onnx-1.16.2-cp38-cp38-win32.whl", hash = "sha256:e16012431643c66124eba0089acdad0df71d5c9d4e6bec4721999f9eecab72b7"},
-    {file = "onnx-1.16.2-cp38-cp38-win_amd64.whl", hash = "sha256:42231a467e5be2974d426b410987073ed85bee34af7b50c93ab221a8696b0cfd"},
-    {file = "onnx-1.16.2-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:e79edba750ae06059d82d8ff8129a6488a7e692cd23cd7fe010f7ec7d6a14bad"},
-    {file = "onnx-1.16.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d192db8501103fede9c1725861e65ed41efb65da1ce915ba969aae40073eb94"},
-    {file = "onnx-1.16.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da01d4a3bd7a0d0ee5084f65441fc9ca38450fc18835b7f9d5da5b9e7ca8b85d"},
-    {file = "onnx-1.16.2-cp39-cp39-win32.whl", hash = "sha256:0b765b09bdb01fa2338ea52483aa3d9c75e249f85446f0d9ad1dc5bd2b149082"},
-    {file = "onnx-1.16.2-cp39-cp39-win_amd64.whl", hash = "sha256:bfee781a59919e797f4dae380e63a0390ec01ce5c337a1459b992aac2f49a3c2"},
-    {file = "onnx-1.16.2.tar.gz", hash = "sha256:b33a282b038813c4b69e73ea65c2909768e8dd6cc10619b70632335daf094646"},
+    {file = "onnx-1.17.0-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:38b5df0eb22012198cdcee527cc5f917f09cce1f88a69248aaca22bd78a7f023"},
+    {file = "onnx-1.17.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d545335cb49d4d8c47cc803d3a805deb7ad5d9094dc67657d66e568610a36d7d"},
+    {file = "onnx-1.17.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3193a3672fc60f1a18c0f4c93ac81b761bc72fd8a6c2035fa79ff5969f07713e"},
+    {file = "onnx-1.17.0-cp310-cp310-win32.whl", hash = "sha256:0141c2ce806c474b667b7e4499164227ef594584da432fd5613ec17c1855e311"},
+    {file = "onnx-1.17.0-cp310-cp310-win_amd64.whl", hash = "sha256:dfd777d95c158437fda6b34758f0877d15b89cbe9ff45affbedc519b35345cf9"},
+    {file = "onnx-1.17.0-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:d6fc3a03fc0129b8b6ac03f03bc894431ffd77c7d79ec023d0afd667b4d35869"},
+    {file = "onnx-1.17.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f01a4b63d4e1d8ec3e2f069e7b798b2955810aa434f7361f01bc8ca08d69cce4"},
+    {file = "onnx-1.17.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a183c6178be001bf398260e5ac2c927dc43e7746e8638d6c05c20e321f8c949"},
+    {file = "onnx-1.17.0-cp311-cp311-win32.whl", hash = "sha256:081ec43a8b950171767d99075b6b92553901fa429d4bc5eb3ad66b36ef5dbe3a"},
+    {file = "onnx-1.17.0-cp311-cp311-win_amd64.whl", hash = "sha256:95c03e38671785036bb704c30cd2e150825f6ab4763df3a4f1d249da48525957"},
+    {file = "onnx-1.17.0-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:0e906e6a83437de05f8139ea7eaf366bf287f44ae5cc44b2850a30e296421f2f"},
+    {file = "onnx-1.17.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d955ba2939878a520a97614bcf2e79c1df71b29203e8ced478fa78c9a9c63c2"},
+    {file = "onnx-1.17.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f3fb5cc4e2898ac5312a7dc03a65133dd2abf9a5e520e69afb880a7251ec97a"},
+    {file = "onnx-1.17.0-cp312-cp312-win32.whl", hash = "sha256:317870fca3349d19325a4b7d1b5628f6de3811e9710b1e3665c68b073d0e68d7"},
+    {file = "onnx-1.17.0-cp312-cp312-win_amd64.whl", hash = "sha256:659b8232d627a5460d74fd3c96947ae83db6d03f035ac633e20cd69cfa029227"},
+    {file = "onnx-1.17.0-cp38-cp38-macosx_12_0_universal2.whl", hash = "sha256:23b8d56a9df492cdba0eb07b60beea027d32ff5e4e5fe271804eda635bed384f"},
+    {file = "onnx-1.17.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ecf2b617fd9a39b831abea2df795e17bac705992a35a98e1f0363f005c4a5247"},
+    {file = "onnx-1.17.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea5023a8dcdadbb23fd0ed0179ce64c1f6b05f5b5c34f2909b4e927589ebd0e4"},
+    {file = "onnx-1.17.0-cp38-cp38-win32.whl", hash = "sha256:f0e437f8f2f0c36f629e9743d28cf266312baa90be6a899f405f78f2d4cb2e1d"},
+    {file = "onnx-1.17.0-cp38-cp38-win_amd64.whl", hash = "sha256:e4673276b558b5b572b960b7f9ef9214dce9305673683eb289bb97a7df379a4b"},
+    {file = "onnx-1.17.0-cp39-cp39-macosx_12_0_universal2.whl", hash = "sha256:67e1c59034d89fff43b5301b6178222e54156eadd6ab4cd78ddc34b2f6274a66"},
+    {file = "onnx-1.17.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e19fd064b297f7773b4c1150f9ce6213e6d7d041d7a9201c0d348041009cdcd"},
+    {file = "onnx-1.17.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8167295f576055158a966161f8ef327cb491c06ede96cc23392be6022071b6ed"},
+    {file = "onnx-1.17.0-cp39-cp39-win32.whl", hash = "sha256:76884fe3e0258c911c749d7d09667fb173365fd27ee66fcedaf9fa039210fd13"},
+    {file = "onnx-1.17.0-cp39-cp39-win_amd64.whl", hash = "sha256:5ca7a0894a86d028d509cdcf99ed1864e19bfe5727b44322c11691d834a1c546"},
+    {file = "onnx-1.17.0.tar.gz", hash = "sha256:48ca1a91ff73c1d5e3ea2eef20ae5d0e709bb8a2355ed798ffc2169753013fd3"},
 ]
 
 [package.dependencies]
@@ -3386,7 +3300,7 @@ numpy = ">=1.20"
 protobuf = ">=3.20.2"
 
 [package.extras]
-reference = ["google-re2", "pillow"]
+reference = ["Pillow", "google-re2"]
 
 [[package]]
 name = "overrides"
@@ -4278,63 +4192,6 @@ files = [
 test = ["pytest (>=3.0)", "pytest-asyncio"]
 
 [[package]]
-name = "ray"
-version = "2.37.0"
-description = "Ray provides a simple, universal API for building distributed applications."
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "ray-2.37.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:96366285038fe0c47e975ffd64eb891f70fb863a80be91c0be64f2ab0cf16d9c"},
-    {file = "ray-2.37.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:31c55de41b7e1899a62f2dd6a693ffca0a4cb52633aa66617e3816d48b70aac3"},
-    {file = "ray-2.37.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:aee7ff189fd52530d020b13c5e7e6da55e65456193a349d39635a72981e521db"},
-    {file = "ray-2.37.0-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:29932441e68ab7dad35b276c763670bf42ebf721cddc4f4de8200bd92ac05c58"},
-    {file = "ray-2.37.0-cp310-cp310-win_amd64.whl", hash = "sha256:8a96139143584558507b7bca05581962d92ff86fdd0c58210ed53adc7340ec98"},
-    {file = "ray-2.37.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:fa642e9b34e88c6a7edb17b291201351d44f063e04ba9f1e83e42aaf492fc14a"},
-    {file = "ray-2.37.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c53ee350a009bab6b811254f8407387812de9a290269e32dbf7c3f0dce6c93c9"},
-    {file = "ray-2.37.0-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:60298e199d9938d3be7418e0645aae312f1283e31123991053d36d0ff1e4ec43"},
-    {file = "ray-2.37.0-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:b420279ca14f02cc27fc592ff1f28da9aa08b962316bf65ddf370db877082e91"},
-    {file = "ray-2.37.0-cp311-cp311-win_amd64.whl", hash = "sha256:7faff20ea7a06612d3cd860a61d2736aa9f82d0d2bcef0917717ced67c8b51c5"},
-    {file = "ray-2.37.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:860f3d45438c3daad30f034f107e3fed05a710c7251e10714f942be598715bd2"},
-    {file = "ray-2.37.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0b8c23ced4186040dee37e982227e3b1296e2fcbd4c520e4399e5d99ed3c641d"},
-    {file = "ray-2.37.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:75cd9a1f6f332ac00d77154b24bd38f4b46a4e600cd02a2440e69b918273b475"},
-    {file = "ray-2.37.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:0268c7bc2e8bb6ef9bb8969299deb5857bf672bfcb59da95db7495a8a502f8ba"},
-    {file = "ray-2.37.0-cp312-cp312-win_amd64.whl", hash = "sha256:4132f79902160c650eaffe1ed1265e5b88d461ff5f3a777a16a750beeed7de1e"},
-    {file = "ray-2.37.0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:448e3f130322dd71c9114b1b7553d0a9c3bf11727555284653dd66e8bbe6677c"},
-    {file = "ray-2.37.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8c38ba452a033f7369a773b170deb8098059459d4cf353fb3bb4cce371cb8233"},
-    {file = "ray-2.37.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:227bfc85661f55b81156cee043690012183a95f89fa421fc2fe3ab085b6656dd"},
-    {file = "ray-2.37.0-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:919df1cf008a4e6c454c97d4a071a72ee62f50ccb7cc715a77764d33ce24afba"},
-    {file = "ray-2.37.0-cp39-cp39-win_amd64.whl", hash = "sha256:35ae20287178e26bff50e404e230197c79419063e70fceb4750694efa66a4e83"},
-]
-
-[package.dependencies]
-aiosignal = "*"
-click = ">=7.0"
-filelock = "*"
-frozenlist = "*"
-jsonschema = "*"
-msgpack = ">=1.0.0,<2.0.0"
-packaging = "*"
-protobuf = ">=3.15.3,<3.19.5 || >3.19.5"
-pyyaml = "*"
-requests = "*"
-
-[package.extras]
-adag = ["cupy-cuda12x"]
-air = ["aiohttp (>=3.7)", "aiohttp-cors", "colorful", "fastapi", "fsspec", "grpcio (>=1.32.0)", "grpcio (>=1.42.0)", "memray", "numpy (>=1.20)", "opencensus", "pandas", "pandas (>=1.3)", "prometheus-client (>=0.7.1)", "py-spy (>=0.2.0)", "pyarrow (>=6.0.1)", "pydantic (<2.0.dev0 || >=2.5.dev0,<3)", "requests", "smart-open", "starlette", "tensorboardX (>=1.9)", "uvicorn[standard]", "virtualenv (>=20.0.24,!=20.21.1)", "watchfiles"]
-all = ["aiohttp (>=3.7)", "aiohttp-cors", "colorful", "cupy-cuda12x", "dm-tree", "fastapi", "fsspec", "grpcio (!=1.56.0)", "grpcio (>=1.32.0)", "grpcio (>=1.42.0)", "gymnasium (==0.28.1)", "lz4", "memray", "numpy (>=1.20)", "opencensus", "opentelemetry-api", "opentelemetry-exporter-otlp", "opentelemetry-sdk", "pandas", "pandas (>=1.3)", "prometheus-client (>=0.7.1)", "py-spy (>=0.2.0)", "pyarrow (>=6.0.1)", "pydantic (<2.0.dev0 || >=2.5.dev0,<3)", "pyyaml", "requests", "rich", "scikit-image", "scipy", "smart-open", "starlette", "tensorboardX (>=1.9)", "typer", "uvicorn[standard]", "virtualenv (>=20.0.24,!=20.21.1)", "watchfiles"]
-all-cpp = ["aiohttp (>=3.7)", "aiohttp-cors", "colorful", "cupy-cuda12x", "dm-tree", "fastapi", "fsspec", "grpcio (!=1.56.0)", "grpcio (>=1.32.0)", "grpcio (>=1.42.0)", "gymnasium (==0.28.1)", "lz4", "memray", "numpy (>=1.20)", "opencensus", "opentelemetry-api", "opentelemetry-exporter-otlp", "opentelemetry-sdk", "pandas", "pandas (>=1.3)", "prometheus-client (>=0.7.1)", "py-spy (>=0.2.0)", "pyarrow (>=6.0.1)", "pydantic (<2.0.dev0 || >=2.5.dev0,<3)", "pyyaml", "ray-cpp (==2.37.0)", "requests", "rich", "scikit-image", "scipy", "smart-open", "starlette", "tensorboardX (>=1.9)", "typer", "uvicorn[standard]", "virtualenv (>=20.0.24,!=20.21.1)", "watchfiles"]
-client = ["grpcio (!=1.56.0)"]
-cpp = ["ray-cpp (==2.37.0)"]
-data = ["fsspec", "numpy (>=1.20)", "pandas (>=1.3)", "pyarrow (>=6.0.1)"]
-default = ["aiohttp (>=3.7)", "aiohttp-cors", "colorful", "grpcio (>=1.32.0)", "grpcio (>=1.42.0)", "memray", "opencensus", "prometheus-client (>=0.7.1)", "py-spy (>=0.2.0)", "pydantic (<2.0.dev0 || >=2.5.dev0,<3)", "requests", "smart-open", "virtualenv (>=20.0.24,!=20.21.1)"]
-observability = ["opentelemetry-api", "opentelemetry-exporter-otlp", "opentelemetry-sdk"]
-rllib = ["dm-tree", "fsspec", "gymnasium (==0.28.1)", "lz4", "pandas", "pyarrow (>=6.0.1)", "pyyaml", "requests", "rich", "scikit-image", "scipy", "tensorboardX (>=1.9)", "typer"]
-serve = ["aiohttp (>=3.7)", "aiohttp-cors", "colorful", "fastapi", "grpcio (>=1.32.0)", "grpcio (>=1.42.0)", "memray", "opencensus", "prometheus-client (>=0.7.1)", "py-spy (>=0.2.0)", "pydantic (<2.0.dev0 || >=2.5.dev0,<3)", "requests", "smart-open", "starlette", "uvicorn[standard]", "virtualenv (>=20.0.24,!=20.21.1)", "watchfiles"]
-serve-grpc = ["aiohttp (>=3.7)", "aiohttp-cors", "colorful", "fastapi", "grpcio (>=1.32.0)", "grpcio (>=1.42.0)", "memray", "opencensus", "prometheus-client (>=0.7.1)", "py-spy (>=0.2.0)", "pydantic (<2.0.dev0 || >=2.5.dev0,<3)", "requests", "smart-open", "starlette", "uvicorn[standard]", "virtualenv (>=20.0.24,!=20.21.1)", "watchfiles"]
-train = ["fsspec", "pandas", "pyarrow (>=6.0.1)", "requests", "tensorboardX (>=1.9)"]
-tune = ["fsspec", "pandas", "pyarrow (>=6.0.1)", "requests", "tensorboardX (>=1.9)"]
-
-[[package]]
 name = "referencing"
 version = "0.35.1"
 description = "JSON Referencing + Python"
@@ -4605,6 +4462,17 @@ doc = ["jupyterlite-pyodide-kernel", "jupyterlite-sphinx (>=0.12.0)", "jupytext"
 test = ["array-api-strict", "asv", "gmpy2", "hypothesis (>=6.30)", "mpmath", "pooch", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
 
 [[package]]
+name = "semver"
+version = "3.0.2"
+description = "Python helper for Semantic Versioning (https://semver.org)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "semver-3.0.2-py3-none-any.whl", hash = "sha256:b1ea4686fe70b981f85359eda33199d60c53964284e0cfb4977d243e37cf4bf4"},
+    {file = "semver-3.0.2.tar.gz", hash = "sha256:6253adb39c70f6e51afed2fa7152bcd414c411286088fb4b9effb133885ab4cc"},
+]
+
+[[package]]
 name = "send2trash"
 version = "1.8.3"
 description = "Send file to trash natively under Mac OS X, Windows and Linux"
@@ -4675,14 +4543,16 @@ files = [
 
 [[package]]
 name = "spython"
-version = "0.3.14"
+version = "0.2.14"
 description = "Command line python tool for working with singularity."
 optional = false
 python-versions = "*"
 files = [
-    {file = "spython-0.3.14-py3-none-any.whl", hash = "sha256:72968583e498bc2a51f9acd0ed6bc0d7d1f7ccd491feaba5e2f7d944bc51da3a"},
-    {file = "spython-0.3.14.tar.gz", hash = "sha256:8ad53ef034395cfa2d8a710cc1c3638e4475e5bbc6a2842d317db8013c2e4188"},
+    {file = "spython-0.2.14.tar.gz", hash = "sha256:49e22fbbdebe456b27ca17d30061489db8e0f95e62be3623267a23b85e3ce0f0"},
 ]
+
+[package.dependencies]
+semver = ">=2.8.1"
 
 [[package]]
 name = "stack-data"
@@ -4787,13 +4657,13 @@ test = ["pytest", "ruff"]
 
 [[package]]
 name = "tomli"
-version = "2.0.1"
+version = "2.0.2"
 description = "A lil' TOML parser"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+    {file = "tomli-2.0.2-py3-none-any.whl", hash = "sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38"},
+    {file = "tomli-2.0.2.tar.gz", hash = "sha256:d46d457a85337051c36524bc5349dd91b1877838e2979ac5ced3e710ed8a60ed"},
 ]
 
 [[package]]
@@ -5004,13 +4874,13 @@ test = ["mypy", "pytest", "typing-extensions"]
 
 [[package]]
 name = "types-python-dateutil"
-version = "2.9.0.20240906"
+version = "2.9.0.20241003"
 description = "Typing stubs for python-dateutil"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "types-python-dateutil-2.9.0.20240906.tar.gz", hash = "sha256:9706c3b68284c25adffc47319ecc7947e5bb86b3773f843c73906fd598bc176e"},
-    {file = "types_python_dateutil-2.9.0.20240906-py3-none-any.whl", hash = "sha256:27c8cc2d058ccb14946eebcaaa503088f4f6dbc4fb6093d3d456a49aef2753f6"},
+    {file = "types-python-dateutil-2.9.0.20241003.tar.gz", hash = "sha256:58cb85449b2a56d6684e41aeefb4c4280631246a0da1a719bdbe6f3fb0317446"},
+    {file = "types_python_dateutil-2.9.0.20241003-py3-none-any.whl", hash = "sha256:250e1d8e80e7bbc3a6c99b907762711d1a1cdd00e978ad39cb5940f6f0a87f3d"},
 ]
 
 [[package]]
@@ -5422,4 +5292,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "28ebea58412f6d17fe9364c2dad7bdad9da4afaab826950072d95e1f6228eac6"
+content-hash = "dd307d6da1aa4d1a3629e57a3d915ec600027796116f49fdae5457c758cfdec9"

--- a/projects/infer/pyproject.toml
+++ b/projects/infer/pyproject.toml
@@ -10,12 +10,11 @@ infer = "infer.cli:main"
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"
 ratelimiter = "^1.2"
-ray = "^2.6"
 jsonargparse = "^4.24"
 tqdm = "^4.66"
 
 # submodules
-ml4gw-hermes = {path = "../../hermes", develop = true, extras = ["serve", "torch"]}
+ml4gw-hermes = {version=">=0.2.0", extras = ["serve", "torch"]}
 
 # local deps
 aframe = {path = "../../", develop = true}

--- a/projects/plots/apptainer.def
+++ b/projects/plots/apptainer.def
@@ -7,7 +7,6 @@ Stage: build
 ../../libs/utils /opt/aframe/libs/utils
 ../../libs/ledger /opt/aframe/libs/ledger
 ../../libs/priors /opt/aframe/libs/priors
-../../hermes /opt/aframe/hermes
 ../../aframe /opt/aframe/aframe
 ../../pyproject.toml /opt/aframe/pyproject.toml
 

--- a/projects/plots/poetry.lock
+++ b/projects/plots/poetry.lock
@@ -15,11 +15,11 @@ cloudpathlib = "^0.18.1"
 kr8s = "^0.10.0"
 law = {git = "https://github.com/riga/law.git", branch = "master"}
 luigi = "^3.0"
-ml4gw-hermes = {path = "hermes", develop = true, extras = ["serve"]}
+ml4gw-hermes = ">=0.2.0"
 numpy = "^1.26.4"
 psutil = "^5.9.8"
 pykube-ng = {version = "^23.6.0", extras = ["oidc"]}
-spython = "^0.3.13"
+spython = "^0.2"
 utils = {path = "libs/utils", develop = true}
 
 [package.source]
@@ -2833,13 +2833,14 @@ name = "ledger"
 version = "0.1.0"
 description = "Objects for storing and manipulating aframe data"
 optional = false
-python-versions = ">=3.8,<3.13"
+python-versions = ">=3.9,<3.13"
 files = []
 develop = true
 
 [package.dependencies]
 bilby = "^2.2.2"
 h5py = "^3.10.0"
+numpy = "^1.26"
 
 [package.source]
 type = "directory"
@@ -3106,28 +3107,28 @@ torchaudio = ">=2.0,<3.0"
 
 [[package]]
 name = "ml4gw-hermes"
-version = "0.0.1"
+version = "0.2.0"
 description = "Inference-as-a-Service deployment made simple"
 optional = false
-python-versions = ">=3.9,<3.13"
-files = []
-develop = true
+python-versions = "<3.13,>=3.9"
+files = [
+    {file = "ml4gw_hermes-0.2.0-py3-none-any.whl", hash = "sha256:30e32135e44d7babed8f4636268a11c47b811a6250b3bc9dc8c066d929d1a388"},
+    {file = "ml4gw_hermes-0.2.0.tar.gz", hash = "sha256:e254f2b3dff8676e75d35c0eb0e7f41d76feb3a74614ab154493ac2f344294c5"},
+]
 
 [package.dependencies]
-protobuf = "^3.17"
-requests = "^2.26.0"
-tblib = "^1.7"
-tritonclient = {version = "^2.22", extras = ["all"]}
+numpy = ">=1.22,<2.0"
+protobuf = ">=3.17,<4.0"
+requests = ">=2.26.0,<3.0.0"
+spython = ">=0.2,<0.3"
+tblib = ">=1.7,<2.0"
+tritonclient = {version = ">=2.22,<3.0", extras = ["all"]}
 
 [package.extras]
 gcs = ["google-cloud-storage (>=1.38,<2.0)"]
 tensorflow = ["tensorflow (<2.17)", "tf-keras (>=2.16,<2.17)"]
 tensorrt = ["nvidia-tensorrt (>=8.0,<9.0)"]
 torch = ["onnx (>=1.15.0,<2.0.0)", "torch (>=2.0,<3.0)", "urllib3 (>=1.26,<2.0)"]
-
-[package.source]
-type = "directory"
-url = "../../hermes"
 
 [[package]]
 name = "mpmath"
@@ -3893,6 +3894,7 @@ develop = true
 [package.dependencies]
 astropy = "^5.0"
 bilby = "^2.2.2"
+numpy = "^1.26.4"
 
 [package.source]
 type = "directory"
@@ -4963,6 +4965,17 @@ requests = "*"
 docs = ["Sphinx"]
 
 [[package]]
+name = "semver"
+version = "3.0.2"
+description = "Python helper for Semantic Versioning (https://semver.org)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "semver-3.0.2-py3-none-any.whl", hash = "sha256:b1ea4686fe70b981f85359eda33199d60c53964284e0cfb4977d243e37cf4bf4"},
+    {file = "semver-3.0.2.tar.gz", hash = "sha256:6253adb39c70f6e51afed2fa7152bcd414c411286088fb4b9effb133885ab4cc"},
+]
+
+[[package]]
 name = "send2trash"
 version = "1.8.3"
 description = "Send file to trash natively under Mac OS X, Windows and Linux"
@@ -5033,14 +5046,16 @@ files = [
 
 [[package]]
 name = "spython"
-version = "0.3.14"
+version = "0.2.14"
 description = "Command line python tool for working with singularity."
 optional = false
 python-versions = "*"
 files = [
-    {file = "spython-0.3.14-py3-none-any.whl", hash = "sha256:72968583e498bc2a51f9acd0ed6bc0d7d1f7ccd491feaba5e2f7d944bc51da3a"},
-    {file = "spython-0.3.14.tar.gz", hash = "sha256:8ad53ef034395cfa2d8a710cc1c3638e4475e5bbc6a2842d317db8013c2e4188"},
+    {file = "spython-0.2.14.tar.gz", hash = "sha256:49e22fbbdebe456b27ca17d30061489db8e0f95e62be3623267a23b85e3ce0f0"},
 ]
+
+[package.dependencies]
+semver = ">=2.8.1"
 
 [[package]]
 name = "stack-data"

--- a/projects/train/apptainer.def
+++ b/projects/train/apptainer.def
@@ -10,7 +10,6 @@ Stage: build
 ../../libs/utils /opt/aframe/libs/utils
 ../../aframe /opt/aframe/aframe
 ../../pyproject.toml /opt/aframe/pyproject.toml
-../../hermes /opt/aframe/hermes
 ../../libs/ledger /opt/aframe/libs/ledger
 ../../libs/architectures /opt/aframe/libs/architectures
 

--- a/projects/train/poetry.lock
+++ b/projects/train/poetry.lock
@@ -15,11 +15,11 @@ cloudpathlib = "^0.18.1"
 kr8s = "^0.10.0"
 law = {git = "https://github.com/riga/law.git", branch = "master"}
 luigi = "^3.0"
-ml4gw-hermes = {path = "hermes", develop = true, extras = ["serve"]}
+ml4gw-hermes = ">=0.2.0"
 numpy = "^1.26.4"
 psutil = "^5.9.8"
 pykube-ng = {version = "^23.6.0", extras = ["oidc"]}
-spython = "^0.3.13"
+spython = "^0.2"
 utils = {path = "libs/utils", develop = true}
 
 [package.source]
@@ -2565,28 +2565,28 @@ torchaudio = ">=2.0,<3.0"
 
 [[package]]
 name = "ml4gw-hermes"
-version = "0.0.1"
+version = "0.2.0"
 description = "Inference-as-a-Service deployment made simple"
 optional = false
-python-versions = ">=3.9,<3.13"
-files = []
-develop = true
+python-versions = "<3.13,>=3.9"
+files = [
+    {file = "ml4gw_hermes-0.2.0-py3-none-any.whl", hash = "sha256:30e32135e44d7babed8f4636268a11c47b811a6250b3bc9dc8c066d929d1a388"},
+    {file = "ml4gw_hermes-0.2.0.tar.gz", hash = "sha256:e254f2b3dff8676e75d35c0eb0e7f41d76feb3a74614ab154493ac2f344294c5"},
+]
 
 [package.dependencies]
-protobuf = "^3.17"
-requests = "^2.26.0"
-tblib = "^1.7"
-tritonclient = {version = "^2.22", extras = ["all"]}
+numpy = ">=1.22,<2.0"
+protobuf = ">=3.17,<4.0"
+requests = ">=2.26.0,<3.0.0"
+spython = ">=0.2,<0.3"
+tblib = ">=1.7,<2.0"
+tritonclient = {version = ">=2.22,<3.0", extras = ["all"]}
 
 [package.extras]
 gcs = ["google-cloud-storage (>=1.38,<2.0)"]
 tensorflow = ["tensorflow (<2.17)", "tf-keras (>=2.16,<2.17)"]
 tensorrt = ["nvidia-tensorrt (>=8.0,<9.0)"]
 torch = ["onnx (>=1.15.0,<2.0.0)", "torch (>=2.0,<3.0)", "urllib3 (>=1.26,<2.0)"]
-
-[package.source]
-type = "directory"
-url = "../../hermes"
 
 [[package]]
 name = "mpmath"
@@ -4250,6 +4250,11 @@ files = [
     {file = "scikit_learn-1.5.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f60021ec1574e56632be2a36b946f8143bf4e5e6af4a06d85281adc22938e0dd"},
     {file = "scikit_learn-1.5.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:394397841449853c2290a32050382edaec3da89e35b3e03d6cc966aebc6a8ae6"},
     {file = "scikit_learn-1.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:57cc1786cfd6bd118220a92ede80270132aa353647684efa385a74244a41e3b1"},
+    {file = "scikit_learn-1.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e9a702e2de732bbb20d3bad29ebd77fc05a6b427dc49964300340e4c9328b3f5"},
+    {file = "scikit_learn-1.5.2-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:b0768ad641981f5d3a198430a1d31c3e044ed2e8a6f22166b4d546a5116d7908"},
+    {file = "scikit_learn-1.5.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:178ddd0a5cb0044464fc1bfc4cca5b1833bfc7bb022d70b05db8530da4bb3dd3"},
+    {file = "scikit_learn-1.5.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7284ade780084d94505632241bf78c44ab3b6f1e8ccab3d2af58e0e950f9c12"},
+    {file = "scikit_learn-1.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:b7b0f9a0b1040830d38c39b91b3a44e1b643f4b36e36567b80b7c6bd2202a27f"},
     {file = "scikit_learn-1.5.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:757c7d514ddb00ae249832fe87100d9c73c6ea91423802872d9e74970a0e40b9"},
     {file = "scikit_learn-1.5.2-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:52788f48b5d8bca5c0736c175fa6bdaab2ef00a8f536cda698db61bd89c551c1"},
     {file = "scikit_learn-1.5.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:643964678f4b5fbdc95cbf8aec638acc7aa70f5f79ee2cdad1eec3df4ba6ead8"},
@@ -4314,6 +4319,17 @@ numpy = ">=1.22.4,<2.3"
 dev = ["cython-lint (>=0.12.2)", "doit (>=0.36.0)", "mypy", "pycodestyle", "pydevtool", "rich-click", "ruff", "types-psutil", "typing_extensions"]
 doc = ["jupyterlite-pyodide-kernel", "jupyterlite-sphinx (>=0.12.0)", "jupytext", "matplotlib (>=3.5)", "myst-nb", "numpydoc", "pooch", "pydata-sphinx-theme (>=0.15.2)", "sphinx (>=5.0.0)", "sphinx-design (>=0.4.0)"]
 test = ["array-api-strict", "asv", "gmpy2", "hypothesis (>=6.30)", "mpmath", "pooch", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
+
+[[package]]
+name = "semver"
+version = "3.0.2"
+description = "Python helper for Semantic Versioning (https://semver.org)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "semver-3.0.2-py3-none-any.whl", hash = "sha256:b1ea4686fe70b981f85359eda33199d60c53964284e0cfb4977d243e37cf4bf4"},
+    {file = "semver-3.0.2.tar.gz", hash = "sha256:6253adb39c70f6e51afed2fa7152bcd414c411286088fb4b9effb133885ab4cc"},
+]
 
 [[package]]
 name = "sentry-sdk"
@@ -4546,14 +4562,16 @@ files = [
 
 [[package]]
 name = "spython"
-version = "0.3.14"
+version = "0.2.14"
 description = "Command line python tool for working with singularity."
 optional = false
 python-versions = "*"
 files = [
-    {file = "spython-0.3.14-py3-none-any.whl", hash = "sha256:72968583e498bc2a51f9acd0ed6bc0d7d1f7ccd491feaba5e2f7d944bc51da3a"},
-    {file = "spython-0.3.14.tar.gz", hash = "sha256:8ad53ef034395cfa2d8a710cc1c3638e4475e5bbc6a2842d317db8013c2e4188"},
+    {file = "spython-0.2.14.tar.gz", hash = "sha256:49e22fbbdebe456b27ca17d30061489db8e0f95e62be3623267a23b85e3ce0f0"},
 ]
+
+[package.dependencies]
+semver = ">=2.8.1"
 
 [[package]]
 name = "sympy"
@@ -4950,7 +4968,7 @@ develop = true
 
 [package.dependencies]
 h5py = "^3.6"
-ml4gw = "^0.5"
+ml4gw = ">=0.5.1"
 s3fs = "^2024"
 
 [package.source]
@@ -5305,4 +5323,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "1458338fa37f41bb7cc0765e0ca7e009d5cfe806598989db65c68d977bfa57aa"
+content-hash = "44573a72d3417025689ab1e512c21bab301dcf3996f47e38eba78ca9ef877637"

--- a/projects/train/pyproject.toml
+++ b/projects/train/pyproject.toml
@@ -39,7 +39,7 @@ urllib3 = ">=1.25.4,<1.27"
 
 # local deps
 utils = {path = "../../libs/utils", develop = true}
-ml4gw = "^0.5"
+ml4gw = ">=0.5.1"
 aframe = {path = "../..", develop = true}
 ledger = {path = "../../libs/ledger", develop = true}
 architectures = {path = "../../libs/architectures", develop = true}

--- a/projects/train/train/callbacks.py
+++ b/projects/train/train/callbacks.py
@@ -32,7 +32,7 @@ class WandbSaveConfig(pl.cli.SaveConfigCallback):
             # pop off unecessary trainer args
             config = self.config.as_dict()
             config.pop("trainer")
-            wandb_logger.experiment.config = config
+            wandb_logger.experiment.config.update(config)
 
 
 class ModelCheckpoint(pl.callbacks.ModelCheckpoint):

--- a/projects/train/train/callbacks.py
+++ b/projects/train/train/callbacks.py
@@ -32,7 +32,7 @@ class WandbSaveConfig(pl.cli.SaveConfigCallback):
             # pop off unecessary trainer args
             config = self.config.as_dict()
             config.pop("trainer")
-            wandb_logger.experiment.config.update(config)
+            wandb_logger.experiment.config = config
 
 
 class ModelCheckpoint(pl.callbacks.ModelCheckpoint):

--- a/projects/train/train/cli.py
+++ b/projects/train/train/cli.py
@@ -12,8 +12,7 @@ from utils.logging import configure_logging
 class AframeCLI(LightningCLI):
     def __init__(self, *args, **kwargs):
         # hack into init to hardcode
-        # parser_mode to omegaconf for all subclasses
-
+        # the WandbSaveConfig callback
         kwargs["save_config_callback"] = WandbSaveConfig
         super().__init__(*args, **kwargs)
 

--- a/projects/train/train/cli.py
+++ b/projects/train/train/cli.py
@@ -17,11 +17,26 @@ class AframeCLI(LightningCLI):
         super().__init__(*args, **kwargs)
 
     def add_arguments_to_parser(self, parser):
+        # link data arguments to model;
+        # some models require information about
+        # sequence length before hand, so we need
+        # to link sample rate and kernel length
         parser.link_arguments(
             "data.num_ifos",
             "model.init_args.arch.init_args.num_ifos",
             apply_on="instantiate",
         )
+        parser.link_arguments(
+            "data.init_args.kernel_length",
+            "model.init_args.arch.init_args.kernel_length",
+            apply_on="parse",
+        )
+        parser.link_arguments(
+            "data.init_args.sample_rate",
+            "model.init_args.arch.init_args.sample_rate",
+            apply_on="parse",
+        )
+
         parser.link_arguments(
             "data.init_args.valid_stride",
             "model.init_args.metric.init_args.stride",

--- a/projects/train/train/cli.py
+++ b/projects/train/train/cli.py
@@ -3,12 +3,20 @@ import os
 import torch
 from lightning.pytorch.cli import LightningCLI
 
+from train.callbacks import WandbSaveConfig
 from train.data import BaseAframeDataset
 from train.model import AframeBase
 from utils.logging import configure_logging
 
 
 class AframeCLI(LightningCLI):
+    def __init__(self, *args, **kwargs):
+        # hack into init to hardcode
+        # parser_mode to omegaconf for all subclasses
+
+        kwargs["save_config_callback"] = WandbSaveConfig
+        super().__init__(*args, **kwargs)
+
     def add_arguments_to_parser(self, parser):
         parser.link_arguments(
             "data.num_ifos",

--- a/projects/train/train/data/base.py
+++ b/projects/train/train/data/base.py
@@ -378,7 +378,7 @@ class BaseAframeDataset(pl.LightningDataModule):
         # now define some of the augmentation transforms
         # that require sample rate information
         self._logger.info("Constructing sample rate dependent transforms")
-        self.build_transforms(sample_rate)
+        self.build_transforms()
         self.transforms_to_device()
 
         # load in our validation background up front and

--- a/projects/train/train/model/base.py
+++ b/projects/train/train/model/base.py
@@ -6,11 +6,7 @@ import ray
 import torch
 from architectures import Architecture
 
-from train.callbacks import (
-    ModelCheckpoint,
-    SaveAugmentedBatch,
-    WandbSaveConfig,
-)
+from train.callbacks import ModelCheckpoint, SaveAugmentedBatch
 from train.metrics import TimeSlideAUROC
 
 Tensor = torch.Tensor
@@ -193,7 +189,7 @@ class AframeBase(pl.LightningModule):
         # and inference tasks
         # checkpoint for saving multiple best models
         callbacks = []
-        callbacks.append(SaveAugmentedBatch(), WandbSaveConfig())
+        callbacks.append(SaveAugmentedBatch())
 
         # if using ray tune don't append lightning
         # model checkpoint since we'll be using ray's

--- a/projects/train/train/model/base.py
+++ b/projects/train/train/model/base.py
@@ -53,8 +53,6 @@ class AframeBase(pl.LightningModule):
         self._logger = self.get_logger()
         self.save_hyperparameters(ignore=["arch", "metric"])
 
-        self.save_hyperparameters(ignore=["arch", "metric"])
-
     def get_logger(self):
         logger_name = "AframeModel"
         logger = logging.getLogger(logger_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,6 @@ exclude = '''
 
 [tool.isort]
 known_first_party = ["aframe", "train", "utils", "online", "data", "infer", "plots", "export", "ledger", "p_astro", "priors"]
-known_third_party = ["amplfi", "hermes"]
+known_third_party = ["amplfi"]
 multi_line_output = 3
 include_trailing_comma = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,14 +12,14 @@ authors = [
 python = ">=3.9,<3.13"
 luigi = "^3.0"
 utils = {path = "./libs/utils", develop = true} 
-ml4gw-hermes = {path = "./hermes", develop = true, extras = ["serve"]}
+ml4gw-hermes = ">=0.2.0" 
 law = {git = "https://github.com/riga/law.git", branch = "master" }
 kr8s = "^0.10.0"
 pykube-ng = {version = "^23.6.0", extras = ["oidc"]}
+spython = "^0.2"
 boto3 = "^1.34.4"
 numpy = "^1.26.4"
 cloudpathlib = "^0.18.1"
-spython = "^0.3.13"
 psutil = "^5.9.8"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
1. Makes export platform configurable on the `law` side
2. Updates the export `project` to be compatible with `TorchScript`
3. Removes `hermes` as submodule
4. Binds `AFRAME_` env vars corresponding to directories so that users can point to one anothers files
5. Fixes issue in recently added `WandbSaveConfig` callback
6. Updates tensorrt in export to `8.5.2.2` to be compatible with triton `23.01`

There is a nasty memory leak in older triton containers `22.XX` when making multi-gpu inference requests with a model exported and hosted with libtorch backend (TorchScript). These went away in `23.01`. 

@wbenoit26 Ready to look over. I snuck in a couple other fixes here, happy to strip them out into separate PRs if that's easier