### PR TITLE
`configure_logging` to all `law` `Tasks` 

### DIFF
--- a/aframe/base.py
+++ b/aframe/base.py
@@ -10,6 +10,7 @@ from law.contrib.singularity.config import config_defaults
 
 from aframe.config import wandb
 from aframe.helm import RayCluster
+from utils.logging import configure_logging
 
 root = Path(__file__).resolve().parent.parent
 logger = logging.getLogger("luigi-interface")
@@ -46,6 +47,17 @@ class AframeParameters(law.Task):
         significant=False,
         description="Comma separated list of gpu ids to be exposed "
         "via the `CUDA_VISIBLE_DEVICES` environment variable.",
+    )
+    log_file = luigi.OptionalParameter(
+        default="",
+        significant=False,
+        description="Path to log file to write logs to. "
+        "If not provided, logs will be written to stdout.",
+    )
+    verbose = luigi.BoolParameter(
+        default=False,
+        significant=False,
+        description="If `True`, log at `DEBUG` verbosity, ",
     )
 
 
@@ -136,6 +148,10 @@ class AframeSandboxTask(law.SandboxTask, AframeParameters):
     # when calling .req() so that individual tasks
     # can speciyfy their own values
     exclude_params_req = {"output_dir", "data_dir"}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        configure_logging(self.log_file, self.verbose)
 
     @property
     def sandbox(self):

--- a/aframe/tasks/data/segments.py
+++ b/aframe/tasks/data/segments.py
@@ -1,3 +1,5 @@
+import logging
+
 import luigi
 
 from aframe.parameters import PathParameter
@@ -36,11 +38,19 @@ class Query(AframeDataTask):
         from data.segments.segments import DataQualityDict
 
         flags = self.get_flags()
+        logging.info(
+            f"Querying active segments in interval ({self.start}, {self.end})"
+        )
         segments = DataQualityDict.query_segments(
             flags,
             self.start,
             self.end,
             self.min_duration,
+        )
+        logging.info(
+            "Discovered {} valid segments, writing to {}".format(
+                len(segments), self.output().path
+            )
         )
         with self.output().open("w") as f:
             segments.write(f, format="segwizard")


### PR DESCRIPTION
adds `configure_logging` call to `law` `Tasks` so that we can catch any `logging` statements made from with `run` methods. Also added `log_file` and `verbose` parameters to each task. 

Down the line, we can figure out the best way to pass `log_file` to each task.