### PR TITLE
Use ligo skymap pool

### DIFF
--- a/projects/online/online/utils/gdb.py
+++ b/projects/online/online/utils/gdb.py
@@ -225,7 +225,6 @@ class GraceDb(_GraceDb):
         result.save_posterior_samples(filename=filename)
 
         args = [
-            "ligo-skymap-from-samples",
             str(filename),
             "-j",
             str(64),


### PR DESCRIPTION
Now that we have our own node, revert back to running `ligo_skymap_from_samples` in python, which will keep process pool of workers ready, eliminating initialization overhead.