### PR TITLE
Reorganize data dirs

### DIFF
--- a/aframe/base.py
+++ b/aframe/base.py
@@ -25,8 +25,10 @@ S3_ENV_VARS = [
 # that should be mounted so that users
 # can point to one anothers directories
 AFRAME_DATA_DIRS = [
-    "AFRAME_TRAIN_DATA_DIR",
-    "AFRAME_TEST_DATA_DIR",
+    "AFRAME_TRAIN_BACKGROUND_DIR",
+    "AFRAME_TRAIN_WAVEFORMS_DIR",
+    "AFRAME_TEST_BACKGROUND_DIR",
+    "AFRAME_TEST_WAVEFORMS_DIR",
     "AFRAME_TRAIN_RUN_DIR",
 ]
 
@@ -172,8 +174,8 @@ class AframeSandboxTask(law.SandboxTask, AframeParameters):
         # that will eventually be merged (and uploaded to s3)
         # but want to keep around in case the workflow fails
         # so that luigi/law caching can keep track of them.
-        # Can't use `AFRAME_TRAIN_DATA_DIR` because that might
-        # refer to an s3/remote directory
+        # Can't use either of the `AFRAME_TRAIN` dirs because
+        # that might refer to an s3/remote directory
         env["AFRAME_TMPDIR"] = os.getenv("AFRAME_TMPDIR", local)
 
         # if gpus are specified, expose them inside container

--- a/aframe/config.py
+++ b/aframe/config.py
@@ -114,18 +114,18 @@ nautilus_urls = {
 
 
 class paths(luigi.Config):
-    train_background = PathParameter(
+    train_background_dir = PathParameter(
         default=os.getenv("AFRAME_TRAIN_BACKGROUND_DIR", "")
     )
-    train_waveforms = PathParameter(
+    train_waveforms_dir = PathParameter(
         default=os.getenv("AFRAME_TRAIN_WAVEFORMS_DIR", "")
     )
     train_rundir = PathParameter(default=os.getenv("AFRAME_TRAIN_RUN_DIR", ""))
     results_dir = PathParameter(default=os.getenv("AFRAME_RESULTS_DIR", ""))
-    test_background = PathParameter(
+    test_background_dir = PathParameter(
         default=os.getenv("AFRAME_TEST_BACKGROUND_DIR", "")
     )
-    test_waveforms = PathParameter(
+    test_waveforms_dir = PathParameter(
         default=os.getenv("AFRAME_TEST_WAVEFORMS_DIR", "")
     )
     condor_dir = PathParameter(default=os.getenv("AFRAME_CONDOR_DIR", ""))

--- a/aframe/config.py
+++ b/aframe/config.py
@@ -114,11 +114,19 @@ nautilus_urls = {
 
 
 class paths(luigi.Config):
-    train_datadir = PathParameter(
-        default=os.getenv("AFRAME_TRAIN_DATA_DIR", "")
+    train_background = PathParameter(
+        default=os.getenv("AFRAME_TRAIN_BACKGROUND_DIR", "")
+    )
+    train_waveforms = PathParameter(
+        default=os.getenv("AFRAME_TRAIN_WAVEFORMS_DIR", "")
     )
     train_rundir = PathParameter(default=os.getenv("AFRAME_TRAIN_RUN_DIR", ""))
     results_dir = PathParameter(default=os.getenv("AFRAME_RESULTS_DIR", ""))
-    test_datadir = PathParameter(default=os.getenv("AFRAME_TEST_DATA_DIR", ""))
+    test_background = PathParameter(
+        default=os.getenv("AFRAME_TEST_BACKGROUND_DIR", "")
+    )
+    test_waveforms = PathParameter(
+        default=os.getenv("AFRAME_TEST_WAVEFORMS_DIR", "")
+    )
     condor_dir = PathParameter(default=os.getenv("AFRAME_CONDOR_DIR", ""))
     tmp_dir = PathParameter(default=os.getenv("AFRAME_TMPDIR", ""))

--- a/aframe/tasks/data/fetch.py
+++ b/aframe/tasks/data/fetch.py
@@ -108,9 +108,11 @@ class Fetch(law.LocalWorkflow, StaticMemoryWorkflow, AframeDataTask):
 # renaming tasks to allow specifying diff params in config files
 class FetchTest(Fetch):
     condor_directory = PathParameter(default=paths().condor_dir / "fetch_test")
-    data_dir = PathParameter(default=paths().test_background)
+    data_dir = PathParameter(
+        default=paths().test_background_dir / "background"
+    )
     segments_file = PathParameter(
-        default=paths().test_background / "segments.txt"
+        default=paths().test_background_dir / "segments.txt"
     )
 
 
@@ -118,7 +120,9 @@ class FetchTrain(Fetch):
     condor_directory = PathParameter(
         default=paths().condor_dir / "fetch_train"
     )
-    data_dir = PathParameter(default=paths().train_background)
+    data_dir = PathParameter(
+        default=paths().train_background_dir / "background"
+    )
     segments_file = PathParameter(
-        default=paths().train_background / "segments.txt"
+        default=paths().train_background_dir / "segments.txt"
     )

--- a/aframe/tasks/data/fetch.py
+++ b/aframe/tasks/data/fetch.py
@@ -108,9 +108,9 @@ class Fetch(law.LocalWorkflow, StaticMemoryWorkflow, AframeDataTask):
 # renaming tasks to allow specifying diff params in config files
 class FetchTest(Fetch):
     condor_directory = PathParameter(default=paths().condor_dir / "fetch_test")
-    data_dir = PathParameter(default=paths().test_datadir / "background")
+    data_dir = PathParameter(default=paths().test_background)
     segments_file = PathParameter(
-        default=paths().test_datadir / "segments.txt"
+        default=paths().test_background / "segments.txt"
     )
 
 
@@ -118,7 +118,7 @@ class FetchTrain(Fetch):
     condor_directory = PathParameter(
         default=paths().condor_dir / "fetch_train"
     )
-    data_dir = PathParameter(default=paths().train_datadir / "background")
+    data_dir = PathParameter(default=paths().train_background)
     segments_file = PathParameter(
-        default=paths().train_datadir / "segments.txt"
+        default=paths().train_background / "segments.txt"
     )

--- a/aframe/tasks/data/waveforms/testing.py
+++ b/aframe/tasks/data/waveforms/testing.py
@@ -61,7 +61,7 @@ class TestingWaveformsParams(WaveformParams):
     output_dir = PathParameter(
         description="Directory where merged waveforms and "
         "rejected parameters will be saved",
-        default=paths().test_datadir,
+        default=paths().test_waveforms,
     )
 
 

--- a/aframe/tasks/data/waveforms/testing.py
+++ b/aframe/tasks/data/waveforms/testing.py
@@ -58,10 +58,15 @@ class TestingWaveformsParams(WaveformParams):
         description="Scale of random jitter to add to injection times",
         default=0.1,
     )
+    background_dir = PathParameter(
+        description="Directory containing background strain data into "
+        "which waveforms will be injected during inference",
+        default=paths().test_background_dir,
+    )
     output_dir = PathParameter(
         description="Directory where merged waveforms and "
         "rejected parameters will be saved",
-        default=paths().test_waveforms,
+        default=paths().test_waveforms_dir,
     )
 
 
@@ -83,8 +88,8 @@ class DeployTestingWaveforms(
         reqs = {}
         reqs["test_segments"] = FetchTest.req(
             self,
-            segments_file=self.output_dir / "segments.txt",
-            data_dir=self.output_dir / "background",
+            segments_file=self.background_dir / "segments.txt",
+            data_dir=self.background_dir / "background",
         )
         return reqs
 

--- a/aframe/tasks/data/waveforms/training.py
+++ b/aframe/tasks/data/waveforms/training.py
@@ -105,8 +105,15 @@ class TrainingWaveforms(AframeDataTask):
             WaveformPolarizationSet,
             "WaveformPolarizationSet",
         )
+        # Read in one of the waveform files so we can get information
+        # for chunking the dataset
+        waveforms = cls.read(self.waveform_files[0]).get_waveforms()
+        num_waveforms = len(waveforms)
+        num_files = len(self.waveform_files)
+
+        chunks = (min(64, num_waveforms * num_files), waveforms.shape[-1])
         with self.output().open("w") as f:
-            cls.aggregate(self.waveform_files, f, clean=True)
+            cls.aggregate(self.waveform_files, f, clean=True, chunks=chunks)
 
         # clean up temporary directory
         shutil.rmtree(self.tmp_dir)

--- a/aframe/tasks/data/waveforms/training.py
+++ b/aframe/tasks/data/waveforms/training.py
@@ -27,7 +27,7 @@ class DeployTrainingWaveforms(
 
     output_dir = PathParameter(
         description="Directory where merged training waveforms will be saved",
-        default=paths().train_datadir,
+        default=paths().train_waveforms,
     )
 
     tmp_dir = PathParameter(

--- a/aframe/tasks/data/waveforms/training.py
+++ b/aframe/tasks/data/waveforms/training.py
@@ -27,7 +27,7 @@ class DeployTrainingWaveforms(
 
     output_dir = PathParameter(
         description="Directory where merged training waveforms will be saved",
-        default=paths().train_waveforms,
+        default=paths().train_waveforms_dir,
     )
 
     tmp_dir = PathParameter(

--- a/aframe/tasks/data/waveforms/validation.py
+++ b/aframe/tasks/data/waveforms/validation.py
@@ -39,9 +39,14 @@ class DeployValidationWaveforms(
         description="Frequency of lowpass filter in Hz",
         default="",
     )
+    background_dir = PathParameter(
+        description="Directory containing background strain data into "
+        "which waveforms will be injected during validation",
+        default=paths().train_background_dir,
+    )
     output_dir = PathParameter(
         description="Directory where merged training waveforms will be saved",
-        default=paths().train_waveforms,
+        default=paths().train_waveforms_dir,
     )
 
     tmp_dir = PathParameter(
@@ -66,8 +71,8 @@ class DeployValidationWaveforms(
         reqs = super().workflow_requires()
         reqs["psd_segment"] = FetchTrain.req(
             self,
-            data_dir=self.output_dir / "background",
-            segments_file=self.output_dir / "segments.txt",
+            data_dir=self.background_dir / "background",
+            segments_file=self.background_dir / "segments.txt",
         )
         return reqs
 

--- a/aframe/tasks/data/waveforms/validation.py
+++ b/aframe/tasks/data/waveforms/validation.py
@@ -41,7 +41,7 @@ class DeployValidationWaveforms(
     )
     output_dir = PathParameter(
         description="Directory where merged training waveforms will be saved",
-        default=paths().train_datadir,
+        default=paths().train_waveforms,
     )
 
     tmp_dir = PathParameter(

--- a/aframe/tasks/train/base.py
+++ b/aframe/tasks/train/base.py
@@ -55,13 +55,19 @@ class TrainBaseParameters(law.Task):
         "will save checkpoints, logs, etc. ",
         default=paths().train_rundir,
     )
-    data_dir = PathParameter(
-        description="Directory where training data is stored."
+    background_dir = PathParameter(
+        description="Directory where training background is stored."
+        "It is expected to contain a set of hdf5 files with names "
+        "`background-<gps_start_time>_<duration>.hdf5` containing "
+        "strain data.",
+        default=paths().train_background_dir,
+    )
+    waveforms_dir = PathParameter(
+        description="Directory where training waveforms are stored."
         "It is expected to contain a `val_waveforms.hdf5` file of "
-        "signals for validation, a `/background` sub-directory containing "
-        "background, and a `training_waveforms.hdf5` file containing "
+        "validation signals and a `training_waveforms.hdf5` file containing "
         "training signals if `precompute_train_waveforms` is set to True.",
-        default=paths().train_datadir,
+        default=paths().train_waveforms_dir,
     )
     precompute_train_waveforms = luigi.BoolParameter(
         default=False,
@@ -128,8 +134,10 @@ class TrainBase(law.Task):
             "--seed_everything",
             str(self.seed),
             f"--data.ifos=[{','.join(self.ifos)}]",
-            "--data.data_dir",
-            str(self.data_dir),
+            "--data.background_dir",
+            str(self.background_dir),
+            "--data.waveforms_dir",
+            str(self.waveforms_dir),
         ]
         args = self.configure_data_args(args)
         if self.use_wandb and not wandb().api_key:

--- a/projects/plots/config.yaml
+++ b/projects/plots/config.yaml
@@ -2,7 +2,8 @@ port: 5005
 app:
   init_args:
     weights: ${oc.env:AFRAME_TRAIN_RUN_DIR}/model.pt
-    data_dir: ${oc.env:AFRAME_TEST_DATA_DIR}
+    background_dir: ${oc.env:AFRAME_TEST_BACKGROUND_DIR}
+    waveforms_dir: ${oc.env:AFRAME_TEST_WAVEFORMS_DIR}
     results_dir: ${oc.env:AFRAME_RESULTS_DIR}
     fftlength: 2
     ifos: ["H1", "L1"]

--- a/projects/plots/plots/vizapp/app.py
+++ b/projects/plots/plots/vizapp/app.py
@@ -24,7 +24,8 @@ class App:
     def __init__(
         self,
         weights: str,
-        data_dir: Path,
+        background_dir: Path,
+        waveforms_dir: Path,
         results_dir: Path,
         ifos: List[str],
         mass_combos: List[tuple],
@@ -49,7 +50,8 @@ class App:
 
         # set attributes that will be accessible
         # to downstream pages
-        self.data_dir = data_dir
+        self.background_dir = background_dir
+        self.waveforms_dir = waveforms_dir
         self.results_dir = results_dir
         self.ifos = ifos
         self.mass_combos = mass_combos
@@ -75,7 +77,9 @@ class App:
 
         # instantiate object for managing
         # data loading and application of vetos
-        self.data_manager = DataManager(results_dir, data_dir, ifos, vetos)
+        self.data_manager = DataManager(
+            results_dir, waveforms_dir, ifos, vetos
+        )
 
         # initialize all our pages and their constituent plots
         self.pages: list["Page"] = []

--- a/projects/plots/plots/vizapp/data.py
+++ b/projects/plots/plots/vizapp/data.py
@@ -38,7 +38,7 @@ class DataManager:
     def __init__(
         self,
         results_dir: Path,
-        data_dir: Path,
+        waveforms_dir: Path,
         ifos: list[str],
         vetos: Optional[VETO_CATEGORIES] = None,
     ):
@@ -46,8 +46,8 @@ class DataManager:
         self.ifos = ifos
         self.vetos = vetos
         # load results and data from the run we're visualizing
-        rejected = data_dir / "rejected-parameters.hdf5"
-        self.response_set = data_dir / "waveforms.hdf5"
+        rejected = waveforms_dir / "rejected-parameters.hdf5"
+        self.response_set = waveforms_dir / "waveforms.hdf5"
 
         self.logger.info(
             "Reading in background, foreground and rejected parameters"

--- a/projects/plots/plots/vizapp/pages/analysis/page.py
+++ b/projects/plots/plots/vizapp/pages/analysis/page.py
@@ -22,7 +22,7 @@ class Analysis(Page):
     def get_analyzer(self):
         return EventAnalyzer(
             self.app.model,
-            self.app.background_dir,
+            self.app.background_dir / "background",
             self.app.data_manager.response_set,
             self.app.psd_length,
             self.app.kernel_length,

--- a/projects/plots/plots/vizapp/pages/analysis/page.py
+++ b/projects/plots/plots/vizapp/pages/analysis/page.py
@@ -22,7 +22,7 @@ class Analysis(Page):
     def get_analyzer(self):
         return EventAnalyzer(
             self.app.model,
-            self.app.data_dir / "background",
+            self.app.background_dir,
             self.app.data_manager.response_set,
             self.app.psd_length,
             self.app.kernel_length,

--- a/projects/train/train.yaml
+++ b/projects/train/train.yaml
@@ -76,6 +76,7 @@ data:
     waveform_sampler:
       class_path: train.data.waveforms.WaveformLoader
       init_args:
+        val_waveform_file: ${oc.env:AFRAME_TRAIN_WAVEFORMS_DIR}/val_waveforms.hdf5
         training_waveform_path: ${oc.env:AFRAME_TRAIN_WAVEFORMS_DIR}/training_waveforms.hdf5
     # waveform_sampler: 
     #   class_path: train.data.waveforms.generator.cbc.CBCGenerator

--- a/projects/train/train.yaml
+++ b/projects/train/train.yaml
@@ -76,12 +76,12 @@ data:
     waveform_sampler:
       class_path: train.data.waveforms.WaveformLoader
       init_args:
-        training_waveform_path: ${oc.env:AFRAME_TRAIN_DATA_DIR}/training_waveforms.hdf5
+        training_waveform_path: ${oc.env:AFRAME_TRAIN_WAVEFORMS_DIR}/training_waveforms.hdf5
     # waveform_sampler: 
     #   class_path: train.data.waveforms.generator.cbc.CBCGenerator
     #   init_args:
     #     training_prior: ./training_prior.yaml
-    #     val_waveform_file: ${oc.env:AFRAME_TRAIN_DATA_DIR}/val_waveforms.hdf5
+    #     val_waveform_file: ${oc.env:AFRAME_TRAIN_WAVEFORMS_DIR}/val_waveforms.hdf5
     #     approximant: ml4gw.waveforms.IMRPhenomPv2
     #     f_min: 20
     #     f_ref: 40

--- a/projects/train/train/cli.py
+++ b/projects/train/train/cli.py
@@ -57,6 +57,16 @@ class AframeCLI(LightningCLI):
             apply_on="parse",
         )
 
+        parser.link_arguments(
+            (
+                "model.init_args.metric.init_args.pool_length",
+                "data.init_args.valid_stride",
+            ),
+            "trainer.num_sanity_val_steps",
+            compute_fn=lambda x, y: int(x / y),
+            apply_on="parse",
+        )
+
 
 def main(args=None):
     cli = AframeCLI(

--- a/projects/train/train/data/base.py
+++ b/projects/train/train/data/base.py
@@ -302,7 +302,7 @@ class BaseAframeDataset(pl.LightningDataModule):
         return int(self.hparams.right_pad * self.hparams.sample_rate)
 
     def train_val_split(self) -> tuple[Sequence[str], Sequence[str]]:
-        fnames = glob.glob(f"{self.background_dir}/*.hdf5")
+        fnames = glob.glob(f"{self.background_dir}/background/*.hdf5")
         fnames = sorted([Path(fname) for fname in fnames])
         durations = [int(fname.stem.split("-")[-1]) for fname in fnames]
         valid_fnames = []

--- a/projects/train/train/data/base.py
+++ b/projects/train/train/data/base.py
@@ -64,8 +64,12 @@ class BaseAframeDataset(pl.LightningDataModule):
     are processed before being passed to a model
 
     Args:
-        data_dir:
-            Path to the directory containing the training data.
+        background_dir:
+            Path to the directory containing the training background.
+            If this is a s3 bucket, it will be downloaded
+            to a local directory.
+        waveforms_dir:
+            Path to the directory containing the training waveforms.
             If this is a s3 bucket, it will be downloaded
             to a local directory.
         ifos:
@@ -145,7 +149,8 @@ class BaseAframeDataset(pl.LightningDataModule):
     def __init__(
         self,
         # data loading args
-        data_dir: str,
+        background_dir: str,
+        waveforms_dir: str,
         ifos: Sequence[str],
         sample_rate: float,
         dec: Distribution,
@@ -209,7 +214,10 @@ class BaseAframeDataset(pl.LightningDataModule):
 
         # generate our local node data directory
         # if our specified data source is remote
-        self.data_dir = fs_utils.get_data_dir(self.hparams.data_dir)
+        self.background_dir = fs_utils.get_data_dir(
+            self.hparams.background_dir
+        )
+        self.waveforms_dir = fs_utils.get_data_dir(self.hparams.waveforms_dir)
         self.verbose = verbose
 
     # ================================================ #
@@ -294,7 +302,7 @@ class BaseAframeDataset(pl.LightningDataModule):
         return int(self.hparams.right_pad * self.hparams.sample_rate)
 
     def train_val_split(self) -> tuple[Sequence[str], Sequence[str]]:
-        fnames = glob.glob(f"{self.data_dir}/background/*.hdf5")
+        fnames = glob.glob(f"{self.background_dir}/*.hdf5")
         fnames = sorted([Path(fname) for fname in fnames])
         durations = [int(fname.stem.split("-")[-1]) for fname in fnames]
         valid_fnames = []
@@ -328,15 +336,25 @@ class BaseAframeDataset(pl.LightningDataModule):
         Download s3 data if it doesn't exist.
         """
         logger = logging.getLogger("AframeDataset")
-        bucket, _ = fs_utils.split_data_dir(self.hparams.data_dir)
+        bucket, _ = fs_utils.split_data_dir(self.hparams.background_dir)
         if bucket is None:
             return
         logger.info(
-            "Downloading data from S3 bucket {} to {}".format(
-                bucket, self.data_dir
+            "Downloading background data from S3 bucket {} to {}".format(
+                bucket, self.background_dir
             )
         )
-        fs_utils.download_training_data(bucket, self.data_dir)
+        fs_utils.download_training_data(bucket, self.background_dir)
+
+        bucket, _ = fs_utils.split_data_dir(self.hparams.waveforms_dir)
+        if bucket is None:
+            return
+        logger.info(
+            "Downloading waveform data from S3 bucket {} to {}".format(
+                bucket, self.waveforms_dir
+            )
+        )
+        fs_utils.download_training_data(bucket, self.waveforms_dir)
 
     def slice_waveforms(self, waveforms: torch.Tensor) -> torch.Tensor:
         """

--- a/scripts/aframe_init.py
+++ b/scripts/aframe_init.py
@@ -208,8 +208,10 @@ def create_offline_runfile(
     content = f"""
     #!/bin/bash
     # Export environment variables
-    export AFRAME_TRAIN_DATA_DIR={base}/data/train
-    export AFRAME_TEST_DATA_DIR={path}/data/test
+    export AFRAME_TRAIN_BACKGROUND_DIR=
+    export AFRAME_TRAIN_WAVEFORMS_DIR={base}/data/train
+    export AFRAME_TEST_BACKGROUND_DIR=
+    export AFRAME_TEST_WAVEFORMS_DIR={path}/data/test
     export AFRAME_TRAIN_RUN_DIR={base}/training
     export AFRAME_CONDOR_DIR={path}/condor
     export AFRAME_RESULTS_DIR={path}/results


### PR DESCRIPTION
@EthanMarx This PR makes it easier to split up the strain directories and waveform directories to cut down on redundant data download. It also fixes a couple of small bugs I found in the training config.