### PR TITLE
change parameters in online project's config and update preprocessor

### DIFF
--- a/projects/online/config.yaml
+++ b/projects/online/config.yaml
@@ -51,17 +51,21 @@ channels: ["H1:GDS-CALIB_STRAIN", "L1:GDS-CALIB_STRAIN", "V1:Hrec_hoft_16384Hz"]
 state_channels: ["H1:GDS-CALIB_STATE_VECTOR", "L1:GDS-CALIB_STATE_VECTOR", "V1:DQ_ANALYSIS_STATE_VECTOR"]
 data_source: "frames"
 sample_rate: 2048
-astro_event_rate: 31
-kernel_length: 1.5
+astro_event_rate: 89
+kernel_length: 20
 online_inference_rate: 512
-offline_inference_rate: 4
+offline_inference_rate: 16
+schedule: [[0, 16, 512], [16, 20, 2048]]
+split: True
+q: 45.6
+spectrogram: [64, 128]
 inference_params: ["chirp_mass", "mass_ratio", "luminosity_distance", "phic", "inclination", "dec", "psi", "phi"]
 psd_length: 64
 amplfi_psd_length: 10
 aframe_right_pad: 0.0
-fduration: 1
+fduration: 2
 amplfi_fduration: 2
-integration_window_length: 1.5
+integration_window_length: 1
 amplfi_kernel_length: 30
 event_position: 29.5
 fftlength: null
@@ -77,7 +81,7 @@ min_samples_per_pix: 5
 server: "local"
 auth_refresh: 300
 ifo_suffix: 
-input_buffer_length: 75
-output_buffer_length: 8
+input_buffer_length: 100
+output_buffer_length: 16
 device: "cuda"
 verbose: true

--- a/projects/online/online/main.py
+++ b/projects/online/online/main.py
@@ -293,7 +293,7 @@ def search(
         # (significant performance speed up)
         if hl_ready:
             logging.debug("Performing inference")
-            y = aframe(whitened)[:, 0]
+            y = aframe(whitened)[0][:, 0]
         else:
             y = torch.ones(whitened.shape[0])
 

--- a/projects/online/online/main.py
+++ b/projects/online/online/main.py
@@ -24,7 +24,7 @@ from online.dataloading import (
 from online.utils.pe import run_amplfi, warmup_amplfi
 from online.utils.searcher import Searcher
 from online.utils.snapshotter import OnlineSnapshotter
-from utils.preprocessing import BatchWhitener
+from utils.preprocessing import TimeSpectrogramPreprocessor
 from online.subprocesses import (
     amplfi_subprocess,
     pastro_subprocess,
@@ -146,7 +146,7 @@ def process_event(
 
 @torch.no_grad()
 def search(
-    whitener: BatchWhitener,
+    whitener: TimeSpectrogramPreprocessor,
     snapshotter: OnlineSnapshotter,
     searcher: Searcher,
     event_queue: Queue,
@@ -357,6 +357,10 @@ def main(
     kernel_length: float,
     online_inference_rate: float,
     offline_inference_rate: float,
+    schedule: list[list[int]],
+    split: bool,
+    q: float,
+    spectrogram_shape: list[int, int],
     psd_length: float,
     amplfi_psd_length: float,
     aframe_right_pad: float,
@@ -430,6 +434,21 @@ def main(
         offline_inference_rate:
             Rate at which inference was performed offline when
             establishing the background and foreground distributions
+        schedule:
+            It specifies which segments of the input to keep and at
+            what sampling rate. Each row of the schedule has the
+            form: [start_time, end_time, target_sample_rate]
+        split:
+            If `True`, then return a list of decimated segments based on
+            the schedule input. If `False`, then return a concatenated
+            single continuous output tensor.
+        q:
+            The Q value to use for the Q transform.
+        spectrogram_shape:
+            The shape of the interpolated spectrogram, specified as
+            ``(num_f_bins, num_t_bins)``. Because the frequency spacing
+            of the Q-tiles is in log-space, the frequency interpolation
+            is log-spaced as well.
         psd_length:
             Length of PSD estimation window in seconds for PSD
             used to whiten aframe data
@@ -799,13 +818,17 @@ def main(
         lowpass=lowpass,
     ).to(device)
 
-    whitener = BatchWhitener(
+    whitener = TimeSpectrogramPreprocessor(
         kernel_length=kernel_length,
         sample_rate=sample_rate,
         inference_sampling_rate=online_inference_rate,
         batch_size=update_size * online_inference_rate,
         fduration=fduration,
         fftlength=fftlength,
+        schedule=schedule,
+        split=split,
+        q=q,
+        spectrogram_shape=spectrogram_shape,
         highpass=highpass,
         lowpass=lowpass,
     ).to(device)


### PR DESCRIPTION
In line 296 of `projects/online/online/main.py`, we only use the score obtained from the timeseries part of the model. An example of the same is as follows:
`aframe = torch.jit.load('../model.pt')`
`timeseries = torch.randn(10, 2, 4*2048)`
`spectrogram = torch.randn(10, 2, 64, 128)`
`out = aframe(timeseries, spectrogram)`
out is a tuple and `out[0]` corresponds to timeseries and `out[1]` corresponds to spectrogram. 

The other change has been made to the whitener, which uses the `TimeSpectrogramPreprocessor`, and added the corresponding arguments to the config.