### PR TITLE
Reduce resample cropping for online deployment

### DIFF
--- a/projects/online/online/dataloading/ngdd.py
+++ b/projects/online/online/dataloading/ngdd.py
@@ -31,10 +31,10 @@ def data_iterator(
         )
     factor = int(factor)
     b, a = build_resample_filter(factor, numtaps)
-    # Need to crop off at least filter size from both sides
-    # of the resampled data. Stick with powers of 2 to
-    # avoid issues coverting between time and samples.
-    crop_size = 2 ** np.ceil(np.log2(numtaps / factor))
+    # Need to crop off at least half the filter size from
+    # both sides of the resampled data. Stick with powers of
+    # 2 to avoid issues coverting between time and samples.
+    crop_size = 2 ** np.ceil(np.log2((numtaps / 2) / factor))
     crop_length = crop_size / sample_rate
 
     frame_buffer = np.zeros((len(ifos), 0))

--- a/projects/online/online/dataloading/ngdd.py
+++ b/projects/online/online/dataloading/ngdd.py
@@ -32,8 +32,9 @@ def data_iterator(
     factor = int(factor)
     b, a = build_resample_filter(factor, numtaps)
     # Need to crop off at least filter size from both sides
-    # of the resampled data
-    crop_size = numtaps // factor + 1
+    # of the resampled data. Stick with powers of 2 to
+    # avoid issues coverting between time and samples.
+    crop_size = 2 ** np.ceil(np.log2(numtaps / factor))
     crop_length = crop_size / sample_rate
 
     frame_buffer = np.zeros((len(ifos), 0))

--- a/projects/online/online/dataloading/ngdd.py
+++ b/projects/online/online/dataloading/ngdd.py
@@ -4,7 +4,10 @@ from typing import List, Optional
 import arrakis
 import numpy as np
 import torch
-from scipy.signal import resample
+from online.dataloading.utils import (
+    resample,
+    build_resample_filter,
+)
 
 STRAIN_SAMPLE_RATE = 16384
 BLOCK_DURATION = 1 / 16
@@ -16,12 +19,29 @@ def data_iterator(
     ifos: List[str],
     sample_rate: float,
     state_channels: Optional[dict[str, str]] = None,
+    numtaps: Optional[int] = 60,
 ) -> torch.Tensor:
     channels = strain_channels + state_channels
+    # build resampling filter
+    factor = STRAIN_SAMPLE_RATE / sample_rate
+    if not factor.is_integer():
+        raise ValueError(
+            f"Specified sample rate {sample_rate} must "
+            f"evenly divide the frame sample rate {STRAIN_SAMPLE_RATE}"
+        )
+    factor = int(factor)
+    b, a = build_resample_filter(factor, numtaps)
+    # Need to crop off at least filter size from both sides
+    # of the resampled data
+    crop_size = numtaps // factor + 1
+    crop_length = crop_size / sample_rate
+
+    frame_buffer = np.zeros((len(ifos), 0))
+    # slicing will take out 1 second of data from a buffer,
+    # removing `crop_size` samples on the right and
+    # `BLOCK_SIZE - crop_size` samples on the left.
+    slc = slice(-int(crop_size + BLOCK_SIZE), -int(crop_size))
     block_buffer = np.zeros((len(ifos), 0))
-    # Blocks delivered in 16th of a second intervals
-    crop_size = int(sample_rate * BLOCK_DURATION)
-    slc = slice(-2 * crop_size, -crop_size)
     last_ready = [True] * len(ifos)
     for block in arrakis.stream(channels):
         ready = [True] * len(ifos)
@@ -41,20 +61,15 @@ def data_iterator(
         )
         block_buffer = np.append(block_buffer, strain_data, axis=1)
         dur = block_buffer.shape[-1] / STRAIN_SAMPLE_RATE
-        # Need at least 3 blocks to be able to crop out edge effects
-        # from resampling and just yield the middle second
-        if dur >= 3 * BLOCK_DURATION:
-            x = resample(
-                block_buffer,
-                int(sample_rate * dur),
-                axis=1,
-                window="hann",
-            )
+        # Need enough time to be able to crop out edge effects
+        # from resampling
+        if dur >= BLOCK_SIZE + 2 * crop_length:
+            x = resample(frame_buffer, factor, b, a)
             x = x[:, slc]
             block_buffer = block_buffer[:, BLOCK_SIZE:]
             yield (
                 torch.Tensor(x).double(),
-                float(block.t0 - BLOCK_DURATION),
+                float(block.t0 - crop_length),
                 last_ready,
             )
 

--- a/projects/online/online/dataloading/ngdd.py
+++ b/projects/online/online/dataloading/ngdd.py
@@ -64,7 +64,7 @@ def data_iterator(
         dur = block_buffer.shape[-1] / STRAIN_SAMPLE_RATE
         # Need enough time to be able to crop out edge effects
         # from resampling
-        if dur >= BLOCK_SIZE + 2 * crop_length:
+        if dur >= BLOCK_DURATION + 2 * crop_length:
             x = resample(frame_buffer, factor, b, a)
             x = x[:, slc]
             block_buffer = block_buffer[:, BLOCK_SIZE:]

--- a/projects/online/online/dataloading/ngdd.py
+++ b/projects/online/online/dataloading/ngdd.py
@@ -40,8 +40,9 @@ def data_iterator(
     frame_buffer = np.zeros((len(ifos), 0))
     # slicing will take out 1 second of data from a buffer,
     # removing `crop_size` samples on the right and
-    # `BLOCK_SIZE - crop_size` samples on the left.
-    slc = slice(-int(crop_size + BLOCK_SIZE), -int(crop_size))
+    # `BLOCK_DURATION * sample_rate - crop_size` samples on the left.
+    resampled_block_size = BLOCK_DURATION * sample_rate
+    slc = slice(-int(crop_size + resampled_block_size), -int(crop_size))
     block_buffer = np.zeros((len(ifos), 0))
     last_ready = [True] * len(ifos)
     for block in arrakis.stream(channels):

--- a/projects/online/online/dataloading/offline.py
+++ b/projects/online/online/dataloading/offline.py
@@ -209,10 +209,10 @@ def offline_data_iterator(
         )
     factor = int(factor)
     b, a = build_resample_filter(factor, numtaps)
-    # Need to crop off at least filter size from both sides
-    # of the resampled data. Stick with powers of 2 to
-    # avoid issues coverting between time and samples.
-    crop_size = 2 ** np.ceil(np.log2(numtaps / factor))
+    # Need to crop off at least half the filter size from
+    # both sides of the resampled data. Stick with powers of
+    # 2 to avoid issues coverting between time and samples.
+    crop_size = 2 ** np.ceil(np.log2((numtaps / 2) / factor))
     crop_length = crop_size / sample_rate
 
     frame_buffer = np.zeros((len(ifos), 0))

--- a/projects/online/online/dataloading/offline.py
+++ b/projects/online/online/dataloading/offline.py
@@ -191,6 +191,7 @@ def offline_data_iterator(
     sample_rate: float,
     ifo_suffix: str = None,
     state_channels: Optional[dict[str, str]] = None,
+    numtaps: Optional[int] = 60,
 ) -> Generator[tuple[torch.Tensor, float, list[bool]], None, None]:
     """
     Similar to `data_iterator` above, but does not
@@ -207,14 +208,18 @@ def offline_data_iterator(
             f"evenly divide the frame sample rate {GWF_SAMPLE_RATE}"
         )
     factor = int(factor)
-    b, a = build_resample_filter(factor)
+    b, a = build_resample_filter(factor, numtaps)
+    # Need to crop off at least filter size from both sides
+    # of the resampled data
+    crop_size = numtaps // factor + 1
+    crop_length = crop_size / sample_rate
 
     frame_buffer = np.zeros((len(ifos), 0))
-    # slice corresponds to middle second of
-    # a 3 second buffer; the middle second is
-    # yielded at each step to mitigate resampling
-    # edge effects
-    buffer_slc = slice(-int(2 * sample_rate), -int(sample_rate))
+    # slicing will take out 1 second of data from a buffer,
+    # removing `crop_size` samples on the right and, because
+    # frames come in 1-second chunks, `sample_rate - crop_size`
+    # samples on the left.
+    buffer_slc = slice(-int(crop_size + sample_rate), -int(crop_size))
 
     last_ready = [True] * len(ifos)
 
@@ -289,9 +294,9 @@ def offline_data_iterator(
                 frame = np.stack(frames)
                 frame_buffer = np.append(frame_buffer, frame, axis=1)
                 dur = frame_buffer.shape[-1] / GWF_SAMPLE_RATE
-                # Need at least 3 seconds to be able to crop out edge effects
-                # from resampling and just yield the middle second
-                if dur >= 3:
+                # Need enough time to be able to crop out edge effects
+                # from resampling
+                if dur >= sample_rate + 2 * crop_length:
                     x = resample(frame_buffer, factor, b, a)
                     x = x[:, buffer_slc]
                     frame_buffer = frame_buffer[:, GWF_SAMPLE_RATE:]
@@ -299,7 +304,11 @@ def offline_data_iterator(
                     # the data quality bits of the previous second
                     # of data, i.e. the middle second of the
                     # buffer that is being yielded as well
-                    yield torch.Tensor(x.copy()).double(), t0 - 1, last_ready
+                    yield (
+                        torch.Tensor(x.copy()).double(),
+                        t0 - crop_length,
+                        last_ready,
+                    )
 
                 last_ready = ready
                 t0 += 1

--- a/projects/online/online/dataloading/offline.py
+++ b/projects/online/online/dataloading/offline.py
@@ -221,8 +221,9 @@ def offline_data_iterator(
     frame_buffer = np.zeros((len(ifos), 0))
     # slicing will take out 1 second of data from a buffer,
     # removing `crop_size` samples on the right and
-    # `BLOCK_SIZE - crop_size` samples on the left.
-    buffer_slc = slice(-int(crop_size + BLOCK_SIZE), -int(crop_size))
+    # `BLOCK_DURATION * sample_rate - crop_size` samples on the left.
+    resampled_block_size = BLOCK_DURATION * sample_rate
+    buffer_slc = slice(-int(crop_size + resampled_block_size), -int(crop_size))
 
     last_ready = [True] * len(ifos)
 

--- a/projects/online/online/dataloading/offline.py
+++ b/projects/online/online/dataloading/offline.py
@@ -303,7 +303,7 @@ def offline_data_iterator(
                 dur = frame_buffer.shape[-1] / GWF_SAMPLE_RATE
                 # Need enough time to be able to crop out edge effects
                 # from resampling
-                if dur >= sample_rate + 2 * crop_length:
+                if dur >= BLOCK_DURATION + 2 * crop_length:
                     x = resample(frame_buffer, factor, b, a)
                     x = x[:, buffer_slc]
                     frame_buffer = frame_buffer[:, BLOCK_SIZE:]

--- a/projects/online/online/dataloading/offline.py
+++ b/projects/online/online/dataloading/offline.py
@@ -16,6 +16,9 @@ import multiprocessing as mp
 
 STATE_VECTOR_SAMPLE_RATE = 16
 
+BLOCK_DURATION = 1
+BLOCK_SIZE = int(BLOCK_DURATION * GWF_SAMPLE_RATE)
+
 
 class OfflineFrameFileLoader:
     def __init__(
@@ -217,10 +220,9 @@ def offline_data_iterator(
 
     frame_buffer = np.zeros((len(ifos), 0))
     # slicing will take out 1 second of data from a buffer,
-    # removing `crop_size` samples on the right and, because
-    # frames come in 1-second chunks, `sample_rate - crop_size`
-    # samples on the left.
-    buffer_slc = slice(-int(crop_size + sample_rate), -int(crop_size))
+    # removing `crop_size` samples on the right and
+    # `BLOCK_SIZE - crop_size` samples on the left.
+    buffer_slc = slice(-int(crop_size + BLOCK_SIZE), -int(crop_size))
 
     last_ready = [True] * len(ifos)
 
@@ -259,9 +261,13 @@ def offline_data_iterator(
             logging.debug(f"Reading frames from timestamp {t0}")
             frames = []
             frame_slc = slice(
-                int(i * GWF_SAMPLE_RATE), int((i + 1) * GWF_SAMPLE_RATE)
+                int(i * GWF_SAMPLE_RATE),
+                int((i + BLOCK_DURATION) * GWF_SAMPLE_RATE),
             )
-            state_vector_slc = slice(int(i * 16), int((i + 1) * 16))
+            state_vector_slc = slice(
+                int(i * STATE_VECTOR_SAMPLE_RATE),
+                int((i + BLOCK_DURATION) * STATE_VECTOR_SAMPLE_RATE),
+            )
             for j, ifo in enumerate(ifos):
                 frames.append(strain[j, frame_slc])
                 # if state channels were specified,
@@ -300,7 +306,7 @@ def offline_data_iterator(
                 if dur >= sample_rate + 2 * crop_length:
                     x = resample(frame_buffer, factor, b, a)
                     x = x[:, buffer_slc]
-                    frame_buffer = frame_buffer[:, GWF_SAMPLE_RATE:]
+                    frame_buffer = frame_buffer[:, BLOCK_SIZE:]
                     # yield last_ready, which corresponds to
                     # the data quality bits of the previous second
                     # of data, i.e. the middle second of the
@@ -312,4 +318,4 @@ def offline_data_iterator(
                     )
 
                 last_ready = ready
-                t0 += 1
+                t0 += BLOCK_DURATION

--- a/projects/online/online/dataloading/offline.py
+++ b/projects/online/online/dataloading/offline.py
@@ -210,8 +210,9 @@ def offline_data_iterator(
     factor = int(factor)
     b, a = build_resample_filter(factor, numtaps)
     # Need to crop off at least filter size from both sides
-    # of the resampled data
-    crop_size = numtaps // factor + 1
+    # of the resampled data. Stick with powers of 2 to
+    # avoid issues coverting between time and samples.
+    crop_size = 2 ** np.ceil(np.log2(numtaps / factor))
     crop_length = crop_size / sample_rate
 
     frame_buffer = np.zeros((len(ifos), 0))

--- a/projects/online/online/dataloading/online.py
+++ b/projects/online/online/dataloading/online.py
@@ -91,8 +91,9 @@ def data_iterator(
     factor = int(factor)
     b, a = build_resample_filter(factor, numtaps)
     # Need to crop off at least filter size from both sides
-    # of the resampled data
-    crop_size = numtaps // factor + 1
+    # of the resampled data. Stick with powers of 2 to
+    # avoid issues coverting between time and samples.
+    crop_size = 2 ** np.ceil(np.log2(numtaps / factor))
     crop_length = crop_size / sample_rate
 
     frame_buffer = np.zeros((len(ifos), 0))

--- a/projects/online/online/dataloading/online.py
+++ b/projects/online/online/dataloading/online.py
@@ -90,10 +90,10 @@ def data_iterator(
         )
     factor = int(factor)
     b, a = build_resample_filter(factor, numtaps)
-    # Need to crop off at least filter size from both sides
-    # of the resampled data. Stick with powers of 2 to
-    # avoid issues coverting between time and samples.
-    crop_size = 2 ** np.ceil(np.log2(numtaps / factor))
+    # Need to crop off at least half the filter size from
+    # both sides of the resampled data. Stick with powers of
+    # 2 to avoid issues coverting between time and samples.
+    crop_size = 2 ** np.ceil(np.log2((numtaps / 2) / factor))
     crop_length = crop_size / sample_rate
 
     frame_buffer = np.zeros((len(ifos), 0))

--- a/projects/online/online/dataloading/online.py
+++ b/projects/online/online/dataloading/online.py
@@ -102,8 +102,9 @@ def data_iterator(
     frame_buffer = np.zeros((len(ifos), 0))
     # slicing will take out 1 second of data from a buffer,
     # removing `crop_size` samples on the right and
-    # `BLOCK_SIZE - crop_size` samples on the left.
-    slc = slice(-int(crop_size + BLOCK_SIZE), -int(crop_size))
+    # `BLOCK_DURATION * sample_rate - crop_size` samples on the left.
+    resampled_block_size = BLOCK_DURATION * sample_rate
+    slc = slice(-int(crop_size + resampled_block_size), -int(crop_size))
     last_ready = [True] * len(ifos)
     while True:
         frames = []

--- a/projects/online/online/dataloading/online.py
+++ b/projects/online/online/dataloading/online.py
@@ -182,7 +182,7 @@ def data_iterator(
             dur = frame_buffer.shape[-1] / GWF_SAMPLE_RATE
             # Need enough time to be able to crop out edge effects
             # from resampling
-            if dur >= sample_rate + 2 * crop_length:
+            if dur >= BLOCK_DURATION + 2 * crop_length:
                 x = resample(frame_buffer, factor, b, a)
                 x = x[:, slc]
                 frame_buffer = frame_buffer[:, BLOCK_SIZE:]

--- a/projects/online/online/dataloading/online.py
+++ b/projects/online/online/dataloading/online.py
@@ -14,6 +14,9 @@ from online.dataloading.utils import (
     is_gwf,
 )
 
+BLOCK_DURATION = 1
+BLOCK_SIZE = int(BLOCK_DURATION * GWF_SAMPLE_RATE)
+
 
 def get_prefix(datadir: Path):
     if not datadir.exists():
@@ -98,10 +101,9 @@ def data_iterator(
 
     frame_buffer = np.zeros((len(ifos), 0))
     # slicing will take out 1 second of data from a buffer,
-    # removing `crop_size` samples on the right and, because
-    # frames come in 1-second chunks, `sample_rate - crop_size`
-    # samples on the left.
-    slc = slice(-int(crop_size + sample_rate), -int(crop_size))
+    # removing `crop_size` samples on the right and
+    # `BLOCK_SIZE - crop_size` samples on the left.
+    slc = slice(-int(crop_size + BLOCK_SIZE), -int(crop_size))
     last_ready = [True] * len(ifos)
     while True:
         frames = []
@@ -183,7 +185,7 @@ def data_iterator(
             if dur >= sample_rate + 2 * crop_length:
                 x = resample(frame_buffer, factor, b, a)
                 x = x[:, slc]
-                frame_buffer = frame_buffer[:, GWF_SAMPLE_RATE:]
+                frame_buffer = frame_buffer[:, BLOCK_SIZE:]
                 # yield last_ready, which corresponds to
                 # the data quality bits of the previous second
                 # of data, i.e. the middle second of the

--- a/projects/online/online/dataloading/online.py
+++ b/projects/online/online/dataloading/online.py
@@ -72,6 +72,7 @@ def data_iterator(
     ifo_suffix: str = None,
     state_channels: Optional[dict[str, str]] = None,
     timeout: Optional[float] = None,
+    numtaps: Optional[int] = 60,
 ) -> Generator[tuple[torch.Tensor, float, list[bool]], None, None]:
     if ifo_suffix is not None:
         ifo_dir = "_".join([ifos[0], ifo_suffix])
@@ -88,14 +89,18 @@ def data_iterator(
             f"evenly divide the frame sample rate {GWF_SAMPLE_RATE}"
         )
     factor = int(factor)
-    b, a = build_resample_filter(factor)
+    b, a = build_resample_filter(factor, numtaps)
+    # Need to crop off at least filter size from both sides
+    # of the resampled data
+    crop_size = numtaps // factor + 1
+    crop_length = crop_size / sample_rate
 
     frame_buffer = np.zeros((len(ifos), 0))
-    # slice corresponds to middle second of
-    # a 3 second buffer; the middle second is
-    # yielded at each step to mitigate resampling
-    # edge effects
-    slc = slice(-int(2 * sample_rate), -int(sample_rate))
+    # slicing will take out 1 second of data from a buffer,
+    # removing `crop_size` samples on the right and, because
+    # frames come in 1-second chunks, `sample_rate - crop_size`
+    # samples on the left.
+    slc = slice(-int(crop_size + sample_rate), -int(crop_size))
     last_ready = [True] * len(ifos)
     while True:
         frames = []
@@ -172,9 +177,9 @@ def data_iterator(
             frame = np.stack(frames)
             frame_buffer = np.append(frame_buffer, frame, axis=1)
             dur = frame_buffer.shape[-1] / GWF_SAMPLE_RATE
-            # Need at least 3 seconds to be able to crop out edge effects
-            # from resampling and just yield the middle second
-            if dur >= 3:
+            # Need enough time to be able to crop out edge effects
+            # from resampling
+            if dur >= sample_rate + 2 * crop_length:
                 x = resample(frame_buffer, factor, b, a)
                 x = x[:, slc]
                 frame_buffer = frame_buffer[:, GWF_SAMPLE_RATE:]
@@ -182,7 +187,11 @@ def data_iterator(
                 # the data quality bits of the previous second
                 # of data, i.e. the middle second of the
                 # buffer that is being yielded as well
-                yield torch.Tensor(x.copy()).double(), t0 - 1, last_ready
+                yield (
+                    torch.Tensor(x.copy()).double(),
+                    t0 - crop_length,
+                    last_ready,
+                )
 
             last_ready = ready
             t0 += length

--- a/projects/online/online/dataloading/utils.py
+++ b/projects/online/online/dataloading/utils.py
@@ -22,8 +22,7 @@ fname_re = re.compile(pattern)
 # reproduce exact parameters of
 # gwpys TimeSeries.resample() method,
 # when downsampling by integer factor
-def build_resample_filter(factor: int):
-    n = 60
+def build_resample_filter(factor: int, n: int = 60):
     filt = signal.firwin(n + 1, 1.0 / factor, window="hamming")
     _, filt = filter_design.parse_filter(filt)
     b, a = filt


### PR DESCRIPTION
Crop only half the filter size from the buffer after resampling to remove latency. With this, we crop only 1/512th of a second, rather than a full second. Below is a comparison of the whitened data at different cropping sizes. The bottom two are 1/512 and 1/1024, respectively, with the latter there to demonstrate that we can't crop less.

<img width="870" height="405" alt="image" src="https://github.com/user-attachments/assets/be3704e8-dbbb-42f1-af6d-7e83fcb02bf3" />

<img width="870" height="405" alt="image" src="https://github.com/user-attachments/assets/2429d70e-1be4-4ede-bc65-ce84f3a8bb8d" />

<img width="870" height="405" alt="image" src="https://github.com/user-attachments/assets/0ab4838a-5ec3-4630-ba45-4e800dde942f" />
