### PR TITLE
Add `intra_op_thread_count` parameter to snapshotter config

### DIFF
--- a/projects/export/export/main.py
+++ b/projects/export/export/main.py
@@ -225,4 +225,8 @@ def export(
     snapshotter.config.sequence_batching.max_sequence_idle_microseconds = int(
         6e10
     )
+
+    # Limit the number of threads the snapshotter uses to avoid system limits
+    snapshotter.config.parameters["intra_op_thread_count"].string_value = "2"
+
     snapshotter.config.write()


### PR DESCRIPTION
For whatever reason, we've just recently starting running into resource issues when running inference on LHO DGX. The number of threads taken up by starting up the tritonserver exceeds the limit set by the system admins. In particular, the snapshotter is taking up most of them. One option is to simply reduce the number of snapshotter instances, or the number of GPUs being used, but changing the number of allowed threads has been the most effective approach.