### PR TITLE
Use Kafka API for GDB event creation

### DIFF
--- a/projects/online/online/main.py
+++ b/projects/online/online/main.py
@@ -2,6 +2,7 @@ import atexit
 import numpy as np
 import logging
 import signal
+from math import floor
 from pathlib import Path
 from queue import Empty
 from typing import Iterable, List, Optional, Tuple, Literal
@@ -53,6 +54,7 @@ def load_model(model: Architecture, weights: Path):
     arch_weights = {
         k.removeprefix("model."): v
         for k, v in checkpoint["state_dict"].items()
+        if k.startswith("model.")
     }
     model.load_state_dict(arch_weights)
     model.eval()
@@ -62,8 +64,9 @@ def load_model(model: Architecture, weights: Path):
 def load_amplfi(model: FlowArchitecture, weights: Path, num_params: int):
     model, checkpoint = load_model(model, weights)
     scaler_weights = {
-        k.removeprefix("scalar."): v
+        k.removeprefix("scaler."): v
         for k, v in checkpoint["state_dict"].items()
+        if k.startswith("scaler.")
     }
     scaler = ChannelWiseScaler(num_params)
     scaler.load_state_dict(scaler_weights)
@@ -241,7 +244,7 @@ def search(
             if X is not None:
                 logging.debug(
                     "Frame {} is not analysis ready. Using dummy values "
-                    "for inference and ignoring any triggers".format(t0)
+                    "for inference and ignoring any triggers".format(floor(t0))
                 )
                 pass
             # or if it's because frames were dropped within the stream
@@ -249,7 +252,7 @@ def search(
             else:
                 logging.warning(
                     "Missing frame files after timestep {}, "
-                    "resetting states".format(t0)
+                    "resetting states".format(floor(t0))
                 )
 
                 state = snapshotter.reset()
@@ -262,7 +265,7 @@ def search(
         elif not in_spec:
             # the frame is analysis ready, but previous frames
             # weren't, so reset our running states
-            logging.info(f"Frame {t0} is ready again, resetting states")
+            logging.info(f"Frame {floor(t0)} is ready again, resetting states")
             state = snapshotter.reset()
             input_buffer.reset()
             output_buffer.reset()

--- a/projects/online/online/monitor/main.py
+++ b/projects/online/online/monitor/main.py
@@ -48,7 +48,7 @@ def main(
         detected_events = [
             event
             for event in detected_event_dir.iterdir()
-            if float(event.name.split("_")[1])
+            if float(event.name.split("_")[1]) > summary_page.start_time
         ]
 
         # The event page will be created/updated only if the event directory

--- a/projects/online/online/subprocesses/events.py
+++ b/projects/online/online/subprocesses/events.py
@@ -3,6 +3,9 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import certifi
+from ligo.gracedb.kafka import GraceDbKafkaProducer
+
 from .utils import subprocess_wrapper
 
 if TYPE_CHECKING:
@@ -23,6 +26,13 @@ def event_creation_subprocess(
 
     # override with subprocesses logger
     gdb.logger = logger
+
+    # Need to create the producer within the subprocess that uses it
+    gdb.kafka_producer = GraceDbKafkaProducer(
+        bootstrap_servers="kafka-dev.ligo.org:9092",
+        service_url=gdb.server.service_url,
+        ca_cert_path=certifi.where(),
+    )
     while True:
         event = event_queue.get()
         logger.debug("Putting event in pastro queue")

--- a/projects/online/online/utils/gdb.py
+++ b/projects/online/online/utils/gdb.py
@@ -87,7 +87,7 @@ class GraceDb(_GraceDb):
         self.kafka_producer = GraceDbKafkaProducer(
             bootstrap_servers="kafka-dev.ligo.org:9092",
             service_url=server.service_url,
-            ca_cert_path=certifi.where()
+            ca_cert_path=certifi.where(),
         )
         self.server = server
         self.write_dir = write_dir

--- a/projects/online/online/utils/gdb.py
+++ b/projects/online/online/utils/gdb.py
@@ -1,3 +1,4 @@
+import certifi
 import json
 import logging
 from datetime import datetime, timezone
@@ -7,6 +8,7 @@ import bilby
 import h5py
 from gwpy.time import tconvert
 from ligo.gracedb.rest import GraceDb as _GraceDb
+from ligo.gracedb.kafka import GraceDbKafkaProducer
 from ligo.skymap.tool.ligo_skymap_plot import main as ligo_skymap_plot
 from ligo.skymap.io.fits import write_sky_map
 from online.utils.searcher import Event
@@ -80,6 +82,12 @@ class GraceDb(_GraceDb):
             **kwargs,
             service_url=server.service_url,
             use_auth="scitoken",
+            api_version="v2",
+        )
+        self.kafka_producer = GraceDbKafkaProducer(
+            bootstrap_servers="kafka-dev.ligo.org:9092",
+            service_url=server.service_url,
+            ca_cert_path=certifi.where()
         )
         self.server = server
         self.write_dir = write_dir
@@ -98,6 +106,7 @@ class GraceDb(_GraceDb):
             pipeline="aframe",
             filename=str(filename),
             search="AllSky",
+            kafka=self.kafka_producer,
         )
 
         self.logger.debug("Event created")

--- a/projects/online/online/utils/gdb.py
+++ b/projects/online/online/utils/gdb.py
@@ -1,4 +1,3 @@
-import certifi
 import json
 import logging
 from datetime import datetime, timezone
@@ -8,7 +7,6 @@ import bilby
 import h5py
 from gwpy.time import tconvert
 from ligo.gracedb.rest import GraceDb as _GraceDb
-from ligo.gracedb.kafka import GraceDbKafkaProducer
 from ligo.skymap.tool.ligo_skymap_plot import main as ligo_skymap_plot
 from ligo.skymap.io.fits import write_sky_map
 from online.utils.searcher import Event
@@ -84,11 +82,10 @@ class GraceDb(_GraceDb):
             use_auth="scitoken",
             api_version="v2",
         )
-        self.kafka_producer = GraceDbKafkaProducer(
-            bootstrap_servers="kafka-dev.ligo.org:9092",
-            service_url=server.service_url,
-            ca_cert_path=certifi.where(),
-        )
+
+        # The kafka producer will be set in the subprocess that uses it
+        self.kafka_producer = None
+
         self.server = server
         self.write_dir = write_dir
         if logger is None:

--- a/projects/online/online/utils/gdb.py
+++ b/projects/online/online/utils/gdb.py
@@ -104,6 +104,7 @@ class GraceDb(_GraceDb):
             filename=str(filename),
             search="AllSky",
             kafka=self.kafka_producer,
+            http_fallback=True,
         )
 
         self.logger.debug("Event created")

--- a/projects/online/pyproject.toml
+++ b/projects/online/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "scipy<1.15",
     "matplotlib==3.9.4",
     "ligo-skymap>=2.4.0,<3",
-    "ligo-gracedb[kafka]==2.15.4",
+    "ligo-gracedb[kafka]>=2.15.4",
     "tables>=3.9",
 ]
 

--- a/projects/online/pyproject.toml
+++ b/projects/online/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "scipy<1.15",
     "matplotlib==3.9.4",
     "ligo-skymap>=2.4.0,<3",
-    "ligo-gracedb>=2.14.1",
+    "ligo-gracedb[kafka]==2.15.4",
     "tables>=3.9",
 ]
 

--- a/projects/online/uv.lock
+++ b/projects/online/uv.lock
@@ -2811,7 +2811,7 @@ requires-dist = [
     { name = "architectures", editable = "../../libs/architectures" },
     { name = "arrakis", specifier = ">=0.2.0,<0.3" },
     { name = "ledger", editable = "../../libs/ledger" },
-    { name = "ligo-gracedb", extras = ["kafka"], specifier = "==2.15.4" },
+    { name = "ligo-gracedb", extras = ["kafka"], specifier = ">=2.15.4" },
     { name = "ligo-skymap", specifier = ">=2.4.0,<3" },
     { name = "matplotlib", specifier = "==3.9.4" },
     { name = "ml4gw", specifier = ">=0.7.4" },

--- a/projects/online/uv.lock
+++ b/projects/online/uv.lock
@@ -478,6 +478,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/c5/ad5ca082b2610defc488679690df8137300c6bb396b24f783e3d74873fa4/bilby.cython-0.5.3-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:264ccd8ca1adabc794931ed6deb5082ad0ed4b52694be8158cb421a80a752bca", size = 351851, upload-time = "2024-08-23T15:22:07.895Z" },
     { url = "https://files.pythonhosted.org/packages/13/26/f0b46d56d278665b484ec421dc571fb28bdd81635137d00e0edc2c8fddc9/bilby.cython-0.5.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:44e5e381c2861e26a4e1fd5c591ea0c3c9a0e2f0d8c78f28f8704abf2945cd8d", size = 1014120, upload-time = "2024-08-23T15:22:09.942Z" },
     { url = "https://files.pythonhosted.org/packages/11/de/02429d598ec5ed4c70113a2c3e8b76a5b113885f85eacdcdaf19cbb6d23d/bilby.cython-0.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:2758256339d7c3703014b265d3a77e0299d5c6264f962bc311c989ac453cbd60", size = 357801, upload-time = "2024-08-23T15:54:20.941Z" },
+    { url = "https://files.pythonhosted.org/packages/73/b9/e8a78c082d8708ea4cc9c65b53dfed9d1d6bc9b3a44d712811b9e55022ee/bilby_cython-0.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:d39ad43c8962a32b7c561ee07f0f9fb9e656a7847b30176695007b31426d2474", size = 363731, upload-time = "2026-02-23T16:52:49.722Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a2/6a8e2a8a0721b758745e2a35f91c5ff380cf0f795408bc74b9aa8c589f0a/bilby_cython-0.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:9aabbcce359c63c78cf1c1bf4d714c438a2936ddd4e061fe90b3320415dd12f6", size = 361366, upload-time = "2026-02-23T16:52:50.964Z" },
 ]
 
 [[package]]
@@ -700,6 +702,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/a8/fb783cb0abe2b5fded9f55e5703015cdf1c9c85b3669087c538dd15a6a86/comm-0.2.2.tar.gz", hash = "sha256:3fd7a84065306e07bea1773df6eb8282de51ba82f77c72f9c85716ab11fe980e", size = 6210, upload-time = "2024-03-12T16:53:41.133Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/75/49e5bfe642f71f272236b5b2d2691cf915a7283cc0ceda56357b61daa538/comm-0.2.2-py3-none-any.whl", hash = "sha256:e6fb86cb70ff661ee8c9c14e7d36d6de3b4066f1441be4063df9c5009f0a64d3", size = 7180, upload-time = "2024-03-12T16:53:39.226Z" },
+]
+
+[[package]]
+name = "confluent-kafka"
+version = "2.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/38/f5855cae6d328fa66e689d068709f91cbbd4d72e7e03959998bd43ac6b26/confluent_kafka-2.13.2.tar.gz", hash = "sha256:619d10d1d77c9821ba913b3e42a33ade7f889f3573c7f3c17b57c3056e3310f5", size = 276068, upload-time = "2026-03-02T12:53:31.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/a7/7dfee75b246f5e5f0832a27e365cd9e8050591c5f4301714672bea2375ce/confluent_kafka-2.13.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e85dc2aaf08dcac610d20b24d252a24891440cf33c09396c957781b8a1f24015", size = 3629660, upload-time = "2026-03-02T12:52:42.595Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/bc6bca93f455e91b41b196bb208b9cbfc517442a65abae2391f1af64cd2f/confluent_kafka-2.13.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:eb1b218beeaae36b3fc94927e30df5f6d662858e766eada2369b290df0b1bff0", size = 3190013, upload-time = "2026-03-02T12:52:44.193Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/ce/2ee04c1b2707b6dd7177eab40fced00b474671d2303e5096d96f3bf7e231/confluent_kafka-2.13.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:69b4286296504b89c0c3cd1e531d12053c633e56d2c5b477ff9000524fe24eb5", size = 3719524, upload-time = "2026-03-02T12:52:45.488Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/93/5c40e2f7eae52774db6b14060254d001ae8c4ef8d4385bf2f13294dd929f/confluent_kafka-2.13.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:e47be4267d3feda5bf1c066f140f61e61ea28bd6ecdb60c2a52ec1a91b8903e7", size = 3976453, upload-time = "2026-03-02T12:52:47.787Z" },
+    { url = "https://files.pythonhosted.org/packages/46/85/a3d25b67470abbd4835fca714a419465323ba79dceefcdda65dfa4415c80/confluent_kafka-2.13.2-cp311-cp311-win_amd64.whl", hash = "sha256:84dd6e7f456910aa4d4763d86efa0dded7167fdf1251b51d808dec0f124f5e13", size = 4097308, upload-time = "2026-03-02T12:52:49.083Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/d3/a845c6993a728b8b6bdce9b500d15c3ec3663cd95d2bbf9c1b8cfd519b17/confluent_kafka-2.13.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:e259c0d2b9a7e16211b45404f62869502246ac3d03e35a1f80720fd09d262457", size = 3635348, upload-time = "2026-03-02T12:52:50.927Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/22/1cb998f7b3ee613d5b29f4b98e4a7539776eb0819b89d7c3cdd19a685692/confluent_kafka-2.13.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:77ea4ceccdbb67498787b7c02cc329c32417bb730e9383f46c74eb9c5851763c", size = 3194667, upload-time = "2026-03-02T12:52:53.468Z" },
+    { url = "https://files.pythonhosted.org/packages/11/38/8a1b12321068e8ae126e62600a55d7a1872f969e1de5ec7f602e0dba8394/confluent_kafka-2.13.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:a64a8967734f865f54b766553d63a40f17081cd3d2c6cfe6d3217aa7494d88fb", size = 3724453, upload-time = "2026-03-02T12:52:55.187Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/06/3effa66c59a69e17cc48c69ae2533699f4321fac1b46741f2e4b1aefb1e7/confluent_kafka-2.13.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:e4cb7d112463ec15a01a3f0e0d20392cda6e46156a6439fcaaad2267696f5cde", size = 3980919, upload-time = "2026-03-02T12:52:56.852Z" },
+    { url = "https://files.pythonhosted.org/packages/98/22/f76a8b85fad652b4d5c0a0259c8f7bb66393d2d9f277631c754c9ebe5092/confluent_kafka-2.13.2-cp312-cp312-win_amd64.whl", hash = "sha256:44496777ff0104421b8f4bb269728e8a5e772c09f34ae813bc47110e0172ebe0", size = 4097817, upload-time = "2026-03-02T12:52:58.831Z" },
 ]
 
 [[package]]
@@ -2073,16 +2093,22 @@ wheels = [
 
 [[package]]
 name = "ligo-gracedb"
-version = "2.14.2"
+version = "2.15.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "igwn-auth-utils" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/63/d42ee081193d7bbd0f449d3eb46566669207d35117e68d74518cf5e41c27/ligo_gracedb-2.14.2.tar.gz", hash = "sha256:cd93fd50c7a999f88ef969826e678bdf99e242090b6d439d230e5f4f8043f39b", size = 2396894, upload-time = "2025-04-11T15:44:18.597Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/7a/6fa8ee52bb99b7d510a51686e7bd935be263031464eb38a710d458893916/ligo_gracedb-2.15.4.tar.gz", hash = "sha256:06c246f76bdded0bbb4c0471e77a69b0da95cdc97f2c6736a3966ad77667a8bb", size = 2444113, upload-time = "2026-03-25T20:23:00.73Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/ad/e00cc582adb7d0f41363e94a894624a357bfeded7aa143ed9c1820ef1d2e/ligo_gracedb-2.14.2-py3-none-any.whl", hash = "sha256:6463af190ac27c136df0a074c4ea1261b407fc568a2a71a4fa04686797e725f5", size = 2454508, upload-time = "2025-04-11T15:44:17.177Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a6/075ee856218dcd9597fbfb829a60b7daf55ed877f2c0493735d7d9a8ea91/ligo_gracedb-2.15.4-py3-none-any.whl", hash = "sha256:3ac1b4dcac86d7f533b931a4ab140f37a09497eea2fbb314c40c34aac57211c2", size = 2516860, upload-time = "2026-03-25T20:22:59.234Z" },
+]
+
+[package.optional-dependencies]
+kafka = [
+    { name = "certifi" },
+    { name = "confluent-kafka" },
 ]
 
 [[package]]
@@ -2761,7 +2787,7 @@ dependencies = [
     { name = "architectures" },
     { name = "arrakis" },
     { name = "ledger" },
-    { name = "ligo-gracedb" },
+    { name = "ligo-gracedb", extra = ["kafka"] },
     { name = "ligo-skymap" },
     { name = "matplotlib" },
     { name = "ml4gw" },
@@ -2785,7 +2811,7 @@ requires-dist = [
     { name = "architectures", editable = "../../libs/architectures" },
     { name = "arrakis", specifier = ">=0.2.0,<0.3" },
     { name = "ledger", editable = "../../libs/ledger" },
-    { name = "ligo-gracedb", specifier = ">=2.14.1" },
+    { name = "ligo-gracedb", extras = ["kafka"], specifier = "==2.15.4" },
     { name = "ligo-skymap", specifier = ">=2.4.0,<3" },
     { name = "matplotlib", specifier = "==3.9.4" },
     { name = "ml4gw", specifier = ">=0.7.4" },


### PR DESCRIPTION
Uses the new GDB API for event creation. I've tested a creating a single event in `test` and it works. I'm running over the O3 MDC right now and we'll see if anything breaks in the next few days. For now, this work only in gracedb-test.

Also fixes a bug I introduced in a previous PR and formats `t0` correctly.