### PR TITLE
Waveform Parameters

### DIFF
--- a/projects/train/train/callbacks.py
+++ b/projects/train/train/callbacks.py
@@ -53,7 +53,6 @@ class ModelCheckpoint(pl.callbacks.ModelCheckpoint):
             [X] = next(iter(trainer.train_dataloader))
             X = X.to(device)
             waveforms, params = trainer.datamodule.waveform_sampler.sample(X)
-            waveforms = trainer.datamodule.slice_waveforms(waveforms)
         X, y, _ = trainer.datamodule.inject(X, waveforms, params)
         if isinstance(X, tuple):
             X = tuple(i.cpu() for i in X)
@@ -96,7 +95,6 @@ class SaveAugmentedBatch(Callback):
                 waveforms, params = trainer.datamodule.waveform_sampler.sample(
                     X
                 )
-                waveforms = trainer.datamodule.slice_waveforms(waveforms)
             X, y, _ = trainer.datamodule.inject(X, waveforms, params)
             # If X is not a tuple, make it one for consistency
             # of format for saving to file below

--- a/projects/train/train/callbacks.py
+++ b/projects/train/train/callbacks.py
@@ -45,14 +45,16 @@ class ModelCheckpoint(pl.callbacks.ModelCheckpoint):
         device = pl_module.device
         # Handle the case of loading training waveforms from disk
         if trainer.datamodule.waveforms_from_disk:
-            [X], waveforms = next(iter(trainer.train_dataloader))
+            [X], (waveforms, params) = next(iter(trainer.train_dataloader))
             X = X.to(device)
             waveforms = waveforms.to(device)
-            X, y = trainer.datamodule.inject(X, waveforms)
+            params = {k: v.to(device) for k, v in params.items()}
         else:
             [X] = next(iter(trainer.train_dataloader))
             X = X.to(device)
-            X, y = trainer.datamodule.inject(X)
+            waveforms, params = trainer.datamodule.waveform_sampler.sample(X)
+            waveforms = trainer.datamodule.slice_waveforms(waveforms)
+        X, y, _ = trainer.datamodule.inject(X, waveforms, params)
         if isinstance(X, tuple):
             X = tuple(i.cpu() for i in X)
         else:
@@ -84,27 +86,32 @@ class SaveAugmentedBatch(Callback):
             # build training batch by hand
             # Handle the case of loading training waveforms from disk
             if trainer.datamodule.waveforms_from_disk:
-                [X], waveforms = next(iter(trainer.train_dataloader))
+                [X], (waveforms, params) = next(iter(trainer.train_dataloader))
                 X = X.to(device)
                 waveforms = waveforms.to(device)
-                X, y = trainer.datamodule.inject(X, waveforms)
+                params = {k: v.to(device) for k, v in params.items()}
             else:
                 [X] = next(iter(trainer.train_dataloader))
                 X = X.to(device)
-                X, y = trainer.datamodule.inject(X)
+                waveforms, params = trainer.datamodule.waveform_sampler.sample(
+                    X
+                )
+                waveforms = trainer.datamodule.slice_waveforms(waveforms)
+            X, y, _ = trainer.datamodule.inject(X, waveforms, params)
             # If X is not a tuple, make it one for consistency
             # of format for saving to file below
             if not isinstance(X, tuple):
                 X = (X,)
 
             # build val batch by hand
-            [background, _, _], [signals] = next(
+            [background, _, _], [signals, params] = next(
                 iter(trainer.datamodule.val_dataloader())
             )
             background = background.to(device)
             signals = signals.to(device)
-            X_bg, X_inj = trainer.datamodule.build_val_batches(
-                background, signals
+            params = {k: v.to(device) for k, v in params.items()}
+            X_bg, X_inj, _ = trainer.datamodule.build_val_batches(
+                background, signals, params
             )
             # Make background and injected validation data into
             # tuples for consistency if necessary

--- a/projects/train/train/data/base.py
+++ b/projects/train/train/data/base.py
@@ -32,6 +32,17 @@ TransformedDist = torch.distributions.TransformedDistribution
 SECONDS_PER_DAY = 86400
 
 
+class _SignalDataset(torch.utils.data.Dataset):
+    def __init__(self, waveforms, params):
+        self.waveforms, self.params = waveforms, params
+
+    def __len__(self):
+        return len(self.waveforms)
+
+    def __getitem__(self, i):
+        return self.waveforms[i], {k: v[i] for k, v in self.params.items()}
+
+
 # TODO: using this right now because
 # lightning.pytorch.utilities.CombinedLoader
 # is not supported when calling `.fit`. Once
@@ -246,14 +257,13 @@ class BaseAframeDataset(pl.LightningDataModule):
         fs_utils.download_training_data(bucket, self.background_dir)
 
         bucket, _ = fs_utils.split_data_dir(self.hparams.waveforms_dir)
-        if bucket is None:
-            return
-        logger.info(
-            "Downloading waveform data from S3 bucket {} to {}".format(
-                bucket, self.waveforms_dir
+        if bucket is not None:
+            logger.info(
+                "Downloading waveform data from S3 bucket {} to {}".format(
+                    bucket, self.waveforms_dir
+                )
             )
-        )
-        fs_utils.download_training_data(bucket, self.waveforms_dir)
+            fs_utils.download_training_data(bucket, self.waveforms_dir)
 
     # ================================================ #
     # Distribution utilities
@@ -374,9 +384,11 @@ class BaseAframeDataset(pl.LightningDataModule):
     @property
     def num_workers(self):
         local_world_size = len(self.trainer.device_ids)
-        return min(
+        num_workers = min(
             self.max_num_workers, int(os.cpu_count() / local_world_size)
         )
+        self._logger.info(f"Using {num_workers} workers for data loading")
+        return num_workers
 
     # ================================================== #
     # Utilities for initial data loading and preparation #
@@ -513,8 +525,8 @@ class BaseAframeDataset(pl.LightningDataModule):
             self.val_batch_size,
         )
 
-        self.val_waveforms = self.waveform_sampler.get_val_waveforms(
-            world_size, rank
+        self.val_waveforms, self.val_params = (
+            self.waveform_sampler.get_val_waveforms(world_size, rank)
         )
         if self.waveforms_from_disk:
             self.waveform_sampler.get_train_waveforms(
@@ -537,9 +549,9 @@ class BaseAframeDataset(pl.LightningDataModule):
         # waveform loader to reduce quantity of data
         # we need to load
         if self.trainer.training and self.waveforms_from_disk:
-            X, waveforms = batch
+            X, [waveforms, params] = batch
             waveforms = self.slice_waveforms(waveforms)
-            batch = X, waveforms
+            batch = X, (waveforms, params)
         return batch
 
     # ============================================== #
@@ -558,17 +570,19 @@ class BaseAframeDataset(pl.LightningDataModule):
             # if we're training, perform random augmentations
             # on input data and use it to impact labels
             if self.waveforms_from_disk:
-                [batch], waveforms = batch
-                batch = self.inject(batch, waveforms)
+                [X], (waveforms, params) = batch
+                batch = self.inject(X=X, waveforms=waveforms, params=params)
             else:
-                [batch] = batch
-                batch = self.inject(batch)
+                [X] = batch
+                waveforms, params = self.waveform_sampler.sample(X)
+                waveforms = self.slice_waveforms(waveforms)
+                batch = self.inject(X=X, waveforms=waveforms, params=params)
         elif self.trainer.validating or self.trainer.sanity_checking:
             # If we're in validation mode but we're not validating
             # on the local device, the relevant tensors will be
             # empty, so just pass them through with a 0 shift to
             # indicate that this should be ignored
-            [background, _, timeslide_idx], [signals] = batch
+            [background, _, timeslide_idx], [signals, params] = batch
 
             # If we're validating, unfold the background
             # data into a batch of overlapping kernels now that
@@ -576,12 +590,16 @@ class BaseAframeDataset(pl.LightningDataModule):
             # much data from CPU to GPU. Once everything is
             # on-device, pre-inject signals into background.
             shift = self.timeslides[timeslide_idx].shift_size
-            X_bg, X_fg = self.build_val_batches(background, signals)
-            batch = (shift, X_bg, X_fg)
+            X_bg, X_fg, params = self.build_val_batches(
+                background=background,
+                signals=signals,
+                params=params,
+            )
+            batch = (shift, X_bg, X_fg, params)
         return batch
 
     @torch.no_grad()
-    def inject(self, X):
+    def inject(self, X: Tensor, waveforms: Tensor, params: dict[str, Tensor]):
         """
         Override this in child classes to define
         application-specific augmentations
@@ -596,7 +614,8 @@ class BaseAframeDataset(pl.LightningDataModule):
         self,
         background: Tensor,
         signals: Tensor,
-    ) -> tuple[Tensor, Tensor, Tensor]:
+        params: dict[str, Tensor],
+    ) -> tuple[Tensor, Tensor, Tensor, dict[str, Tensor]]:
         """
         Unfold a timeseries of background data
         into a batch of kernels, then inject
@@ -606,9 +625,11 @@ class BaseAframeDataset(pl.LightningDataModule):
         Args:
             background: A tensor of background data
             signals: A tensor of signals to inject
+            params: A dictionary of parameter tensors to be passed to the model
 
         Returns:
-            raw strain background kernels, injected kernels, and psds
+            raw strain background kernels, injected kernels, psds,
+            and (potentially truncated) params tensor
         """
 
         # unfold the background data into kernels
@@ -625,6 +646,7 @@ class BaseAframeDataset(pl.LightningDataModule):
         step = int(len(X) / len(signals))
         if not step:
             signals = signals[: len(X)]
+            params = {k: v[: len(X)] for k, v in params.items()}
         else:
             X = X[::step][: len(signals)]
             psd = psd[::step][: len(signals)]
@@ -658,7 +680,7 @@ class BaseAframeDataset(pl.LightningDataModule):
             X_inj.append(injected)
         X_inj = torch.stack(X_inj)
 
-        return X, X_inj, psd
+        return X, X_inj, psd, params
 
     def val_dataloader(self) -> ZippedDataset:
         """
@@ -676,7 +698,9 @@ class BaseAframeDataset(pl.LightningDataModule):
         # throughout all those batches.
         num_waveforms = len(self.val_waveforms)
         signal_batch_size = (num_waveforms - 1) // self.valid_loader_length + 1
-        signal_dataset = torch.utils.data.TensorDataset(self.val_waveforms)
+
+        # Signal dataset to return tuples of (waveform, params)
+        signal_dataset = _SignalDataset(self.val_waveforms, self.val_params)
         signal_loader = torch.utils.data.DataLoader(
             signal_dataset,
             batch_size=signal_batch_size,

--- a/projects/train/train/data/base.py
+++ b/projects/train/train/data/base.py
@@ -575,7 +575,6 @@ class BaseAframeDataset(pl.LightningDataModule):
             else:
                 [X] = batch
                 waveforms, params = self.waveform_sampler.sample(X)
-                waveforms = self.slice_waveforms(waveforms)
                 batch = self.inject(X=X, waveforms=waveforms, params=params)
         elif self.trainer.validating or self.trainer.sanity_checking:
             # If we're in validation mode but we're not validating

--- a/projects/train/train/data/supervised/multimodal.py
+++ b/projects/train/train/data/supervised/multimodal.py
@@ -4,8 +4,10 @@ from train.data.supervised.supervised import SupervisedAframeDataset
 
 
 class MultiModalSupervisedAframeDataset(SupervisedAframeDataset):
-    def build_val_batches(self, background, signals):
-        X_bg, X_inj, psds = super().build_val_batches(background, signals)
+    def build_val_batches(self, background, signals, params):
+        X_bg, X_inj, psds, params = super().build_val_batches(
+            background=background, signals=signals, params=params
+        )
         X_bg = self.whitener(X_bg, psds)
         X_bg_fft = self.compute_frequency_domain_data(X_bg, psds)
         # whiten each view of injections
@@ -23,7 +25,7 @@ class MultiModalSupervisedAframeDataset(SupervisedAframeDataset):
         asds *= 1e23
         asds = asds.float()
 
-        return (X_bg, X_bg_fft), (X_fg, X_fg_fft)
+        return (X_bg, X_bg_fft), (X_fg, X_fg_fft), params
 
     def compute_frequency_domain_data(self, X, psds):
         asds = psds**0.5
@@ -53,9 +55,11 @@ class MultiModalSupervisedAframeDataset(SupervisedAframeDataset):
 
         return X_fft
 
-    def inject(self, X, waveforms=None):
-        X, y, psds = super().inject(X, waveforms)
+    def inject(self, X, waveforms, params):
+        X, y, psds, params_out = super().inject(
+            X=X, waveforms=waveforms, params=params
+        )
         X = self.whitener(X, psds)
         X_fft = self.compute_frequency_domain_data(X, psds)
 
-        return (X, X_fft), y
+        return (X, X_fft), y, params_out

--- a/projects/train/train/data/supervised/supervised.py
+++ b/projects/train/train/data/supervised/supervised.py
@@ -16,7 +16,7 @@ class SupervisedAframeDataset(BaseAframeDataset):
         **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
-        if swap_prob is not None and 0 < swap_prob < 1:
+        if swap_prob is not None and 0 <= swap_prob <= 1:
             self.swapper = aug.ChannelSwapper(swap_prob)
             self.swap_prob = swap_prob
         elif swap_prob is not None:
@@ -27,7 +27,7 @@ class SupervisedAframeDataset(BaseAframeDataset):
             self.swapper = None
             self.swap_prob = 0
 
-        if mute_prob is not None and 0 < mute_prob < 1:
+        if mute_prob is not None and 0 <= mute_prob <= 1:
             self.muter = aug.ChannelMuter(mute_prob)
             self.mute_prob = mute_prob
         elif mute_prob is not None:
@@ -43,11 +43,14 @@ class SupervisedAframeDataset(BaseAframeDataset):
         return self.hparams.waveform_prob + self.swap_prob + self.mute_prob
 
     @torch.no_grad()
-    def inject(self, X, waveforms=None):
-        if self.waveforms_from_disk and waveforms is None:
+    def inject(
+        self, X, waveforms, params
+    ) -> tuple[
+        torch.Tensor, torch.Tensor, torch.Tensor, dict[str, torch.Tensor]
+    ]:
+        if waveforms is None:
             raise ValueError(
-                "Waveforms should be passed to the `inject` method "
-                "if waveforms are being loaded from disk, got None"
+                "Waveforms should be passed to the `inject` method, got None"
             )
 
         X, psds = self.psd_estimator(X)
@@ -60,25 +63,22 @@ class SupervisedAframeDataset(BaseAframeDataset):
         mask = rvs < self.sample_prob
 
         dec, psi, phi = self.sample_extrinsic(X[mask])
-        # If we're loading waveforms from disk, we can
-        # slice out the ones we want.
-        # If not, we're generating them on the fly.
-        if self.waveforms_from_disk:
-            # TODO: Can we just use `mask` to slice out the
-            # waveforms we want here? Copying this from the
-            # old `WaveformSampler` in case it handles edge
-            # cases I'm not thinking of
-            N = mask.sum().item()
-            idx = torch.randperm(waveforms.shape[0])[:N]
-            waveforms = waveforms[idx].to(X.device).float()
-            hc, hp = waveforms[:, 0], waveforms[:, 1]
-        else:
-            hc, hp = self.waveform_sampler.sample(X[mask])
+        N = mask.sum().item()
+        idx = torch.randperm(waveforms.shape[0])[:N]
+        waveforms = waveforms[idx].to(X.device).float()
+        params = {k: v[idx].to(X.device).float() for k, v in params.items()}
+        hc, hp = waveforms[:, 0], waveforms[:, 1]
 
         snrs = self.snr_sampler.sample((mask.sum().item(),)).to(X.device)
         responses = self.projector(
             dec, psi, phi, snrs, psds[mask], cross=hc, plus=hp
         )
+
+        params["dec"] = dec
+        params["psi"] = psi
+        params["phi"] = phi
+        params["snr"] = snrs
+
         # If we're loading waveforms from disk, we'll have sliced
         # the waveforms already in `on_before_batch_transfer`
         if not self.waveforms_from_disk:
@@ -106,4 +106,12 @@ class SupervisedAframeDataset(BaseAframeDataset):
         y = torch.zeros((X.size(0), 1), device=X.device)
         y[mask] += 1
 
-        return X, y, psds
+        # return NaN for params that weren't injected
+        still_injected = mask[idx]
+        params_out = {}
+        for key, vals in params.items():
+            out = torch.full((X.size(0),), float("nan"), device=X.device)
+            out[idx[still_injected]] = vals[still_injected]
+            params_out[key] = out
+
+        return X, y, psds, params_out

--- a/projects/train/train/data/supervised/time_domain.py
+++ b/projects/train/train/data/supervised/time_domain.py
@@ -7,8 +7,10 @@ from ml4gw.transforms import Heterodyne
 
 
 class TimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
-    def build_val_batches(self, background, signals):
-        X_bg, X_inj, psds = super().build_val_batches(background, signals)
+    def build_val_batches(self, background, signals, params):
+        X_bg, X_inj, psds, params_out = super().build_val_batches(
+            background=background, signals=signals, params=params
+        )
         X_bg = self.whitener(X_bg, psds)
         # whiten each view of injections
         X_fg = []
@@ -17,12 +19,14 @@ class TimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
             X_fg.append(inj)
 
         X_fg = torch.stack(X_fg)
-        return X_bg, X_fg
+        return X_bg, X_fg, params_out
 
-    def inject(self, X, waveforms=None):
-        X, y, psds = super().inject(X, waveforms)
+    def inject(self, X, waveforms, params):
+        X, y, psds, params_out = super().inject(
+            X=X, waveforms=waveforms, params=params
+        )
         X = self.whitener(X, psds)
-        return X, y
+        return X, y, params_out
 
 
 class HeterodyneTimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
@@ -104,8 +108,11 @@ class HeterodyneTimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
                 f"Invalid chirp mass spacing: {chirp_mass_spacing}"
             )
 
-    def build_val_batches(self, background, signals):
-        X_bg, X_inj, psds = super().build_val_batches(background, signals)
+    def build_val_batches(self, background, signals, params):
+        X_bg, X_inj, psds, params_out = super().build_val_batches(
+            background=background, signals=signals, params=params
+        )
+
         X_bg = self.whitener(X_bg, psds)
         X_bg = self.heterodyne_transform(X_bg)
         _B_bg, _C_bg, _M_bg, _T_bg = X_bg.shape
@@ -121,20 +128,24 @@ class HeterodyneTimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
         X_fg = X_fg.view(_V_fg, _B_fg, _C_fg * _M_fg, _T_fg)
 
         if self.keep_last_n_seconds is not None:
-            return X_bg[..., -self.keep_last_n_samples :], X_fg[
-                ..., -self.keep_last_n_samples :
-            ]
+            return (
+                X_bg[..., -self.keep_last_n_samples :],
+                X_fg[..., -self.keep_last_n_samples :],
+                params_out,
+            )
         else:
-            return X_bg, X_fg
+            return X_bg, X_fg, params_out
 
-    def inject(self, X, waveforms=None):
-        X, y, psds = super().inject(X, waveforms)
+    def inject(self, X, waveforms, params):
+        X, y, psds, params_out = super().inject(
+            X=X, waveforms=waveforms, params=params
+        )
         X = self.whitener(X, psds)
         X = self.heterodyne_transform(X)
         _B, _C, _M, _T = X.shape
         X = X.view(_B, _C * _M, _T)
 
         if self.keep_last_n_seconds is not None:
-            return X[..., -self.keep_last_n_samples :], y
+            return X[..., -self.keep_last_n_samples :], y, params_out
         else:
-            return X, y
+            return X, y, params_out

--- a/projects/train/train/data/supervised/time_frequency_domain.py
+++ b/projects/train/train/data/supervised/time_frequency_domain.py
@@ -23,16 +23,20 @@ class SpectrogramDomainSupervisedAframeDataset(SupervisedAframeDataset):
             spectrogram_shape=self.spectrogram_shape,
         )
 
-    def inject(self, X, waveforms=None):
-        X, y, psds = super().inject(X, waveforms)
+    def inject(self, X, waveforms, params):
+        X, y, psds, params_out = super().inject(
+            X=X, waveforms=waveforms, params=params
+        )
         X = self.whitener(X, psds)
         X = self.qtransform(X)
-        return X, y
+        return X, y, params_out
 
     def build_val_batches(
-        self, background: Tensor, signals: Tensor
+        self, background: Tensor, signals: Tensor, params: dict[str, Tensor]
     ) -> tuple[Tensor, Tensor]:
-        X_bg, X_inj, psds = super().build_val_batches(background, signals)
+        X_bg, X_inj, psds, params_out = super().build_val_batches(
+            background=background, signals=signals, params=params
+        )
 
         # whiten and q transform background
         X_bg = self.whitener(X_bg, psds)
@@ -45,7 +49,7 @@ class SpectrogramDomainSupervisedAframeDataset(SupervisedAframeDataset):
             X_fg.append(self.qtransform(inj))
 
         X_fg = torch.stack(X_fg)
-        return X_bg, X_fg
+        return X_bg, X_fg, params_out
 
 
 class FrequencyDomainSupervisedAframeDataset(SupervisedAframeDataset):
@@ -106,7 +110,9 @@ class FrequencyDomainSupervisedAframeDataset(SupervisedAframeDataset):
         return X
 
     def build_val_batches(self, *args, **kwargs):
-        X_bg, X_inj, psds = super().build_val_batches(*args, **kwargs)
+        X_bg, X_inj, psds, params_out = super().build_val_batches(
+            *args, **kwargs
+        )
 
         # fft whiten and bandpass in frequency domain
         X_bg = self.whiten(X_bg, psds)
@@ -115,17 +121,19 @@ class FrequencyDomainSupervisedAframeDataset(SupervisedAframeDataset):
         X_bg = torch.cat([X_bg.real, X_bg.imag], dim=-2)
         X_inj = torch.cat([X_inj.real, X_inj.imag], dim=-2)
 
-        return X_bg, X_inj
+        return X_bg, X_inj, params_out
 
-    def inject(self, X, waveforms=None):
-        X, y, psds = super().inject(X, waveforms)
+    def inject(self, X, waveforms, params):
+        X, y, psds, params_out = super().inject(
+            X=X, waveforms=waveforms, params=params
+        )
 
         # fft whiten and bandpass in frequency domain
         X = self.whiten(X, psds)
 
         # split into real and imaginary parts
         X = torch.cat([X.real, X.imag], dim=1)
-        return X, y
+        return X, y, params_out
 
 
 class TimeSpectrogramDomainSupervisedAframeDataset(SupervisedAframeDataset):
@@ -190,8 +198,10 @@ class TimeSpectrogramDomainSupervisedAframeDataset(SupervisedAframeDataset):
             spectrogram_shape=self.spectrogram_shape,
         )
 
-    def build_val_batches(self, background, signals):
-        X_bg, X_inj, psds = super().build_val_batches(background, signals)
+    def build_val_batches(self, background, signals, params):
+        X_bg, X_inj, psds, params_out = super().build_val_batches(
+            background=background, signals=signals, params=params
+        )
 
         # whiten each view of backgrounds and injections
         X_bg = self.whitener(X_bg, psds)
@@ -215,10 +225,12 @@ class TimeSpectrogramDomainSupervisedAframeDataset(SupervisedAframeDataset):
         X_fg_spec = torch.stack(X_fg_spec)
 
         # first input is timeseries and second input is spectrogram
-        return (X_bg[1], X_bg_spec), (X_fg[1], X_fg_spec)
+        return (X_bg[1], X_bg_spec), (X_fg[1], X_fg_spec), params_out
 
-    def inject(self, X, waveforms=None):
-        X, y, psds = super().inject(X, waveforms)
+    def inject(self, X, waveforms, params):
+        X, y, psds, params_out = super().inject(
+            X=X, waveforms=waveforms, params=params
+        )
         X = self.whitener(X, psds)
         if self.decimator is not None:
             X = self.decimator(X)
@@ -227,4 +239,4 @@ class TimeSpectrogramDomainSupervisedAframeDataset(SupervisedAframeDataset):
         X_spec = self.qtransform(X[0])
 
         # first input is timeseries and second input is spectrogram
-        return (X[1], X_spec), y
+        return (X[1], X_spec), y, params_out

--- a/projects/train/train/data/waveforms/generator/cbc.py
+++ b/projects/train/train/data/waveforms/generator/cbc.py
@@ -55,6 +55,4 @@ class CBCGenerator(WaveformGenerator):
 
     def forward(self, **parameters) -> torch.Tensor:
         hc, hp = self.waveform_generator(**parameters)
-        waveforms = torch.stack([hc, hp], dim=1)
-        hc, hp = waveforms.transpose(1, 0)
-        return hc.float(), hp.float()
+        return torch.stack([hc, hp], dim=1).float()

--- a/projects/train/train/data/waveforms/generator/generator.py
+++ b/projects/train/train/data/waveforms/generator/generator.py
@@ -29,8 +29,8 @@ class WaveformGenerator(WaveformSampler):
     def sample(self, X: torch.Tensor):
         N = len(X)
         parameters = self.training_prior(N, device=X.device)
-        hc, hp = self(**parameters)
-        return hc, hp
+        waveforms = self(**parameters)
+        return waveforms, parameters
 
     def forward(self):
         raise NotImplementedError

--- a/projects/train/train/data/waveforms/loader.py
+++ b/projects/train/train/data/waveforms/loader.py
@@ -90,7 +90,7 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
         batch_size: int,
         batches_per_epoch: int,
         chunk_size: int = 1000,
-        path: Optional[Path] = None,
+        path: Optional[Path | str] = None,
     ):
         self.fnames = fnames
         self.channels = channels
@@ -99,7 +99,7 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
         self.chunk_size = chunk_size
 
         if path is not None:
-            self.path = path.parts
+            self.path = Path(path).parts
         else:
             self.path = None
 
@@ -112,6 +112,7 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
         # of interest in a dictionary so we
         # can access them at will without needing
         # to reopen the files each time
+        self.param_keys = None
         for fname in self.fnames:
             f, g = self.open(fname)
             self.mmap_files[fname] = f
@@ -120,7 +121,14 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
             }
 
             pm_grp = f["parameters"]
-            self.param_keys = list(pm_grp.keys())
+            keys = list(pm_grp.keys())
+            if self.param_keys is None:
+                self.param_keys = keys
+            elif set(keys) != set(self.param_keys):
+                raise ValueError(
+                    f"Parameter keys in {fname} ({keys}) do not match "
+                    f"those in the first file ({self.param_keys})"
+                )
             self.param_datasets[fname] = {
                 k: pm_grp[k] for k in self.param_keys
             }

--- a/projects/train/train/data/waveforms/loader.py
+++ b/projects/train/train/data/waveforms/loader.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import logging
 import math
 import warnings
-from typing import Iterable, Optional
+from typing import Sequence, Optional
 
 import h5py
 import numpy as np
@@ -85,8 +85,8 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
 
     def __init__(
         self,
-        fnames: Iterable[Path],
-        channels: Iterable[str],
+        fnames: Sequence[Path],
+        channels: Sequence[str],
         batch_size: int,
         batches_per_epoch: int,
         chunk_size: int = 1000,
@@ -99,13 +99,14 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
         self.chunk_size = chunk_size
 
         if path is not None:
-            self.path = path.split("/")
+            self.path = path.parts
         else:
             self.path = None
 
         self.sizes = {}
         self.mmap_files = {}
         self.mmap_datasets = {}
+        self.param_datasets = {}
 
         # for each file store the datasets
         # of interest in a dictionary so we
@@ -116,6 +117,12 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
             self.mmap_files[fname] = f
             self.mmap_datasets[fname] = {
                 channel: g[channel] for channel in self.channels
+            }
+
+            pm_grp = f["parameters"]
+            self.param_keys = list(pm_grp.keys())
+            self.param_datasets[fname] = {
+                k: pm_grp[k] for k in self.param_keys
             }
 
             # store sizes of each dataset and warn if not chunked;
@@ -167,16 +174,28 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
 
     def load_chunk(self, fname, start, size):
         end = min(start + size, self.sizes[fname])
-        return {
+        waveforms = {
             channel: self.mmap_datasets[fname][channel][start:end]
             for channel in self.channels
         }
+        params = {
+            k: self.param_datasets[fname][k][start:end]
+            for k in self.param_keys
+        }
+        return waveforms, params
 
     def sample_batch(self):
         # allocate batch up front
         batch = np.zeros(
             (self.batch_size, self.num_channels, self.waveform_size)
         )
+        params_buf = {
+            k: np.zeros(
+                self.batch_size,
+                dtype=self.param_datasets[self.fnames[0]][k].dtype,
+            )
+            for k in self.param_keys
+        }
 
         for i in range(self.chunks_per_batch):
             fname = np.random.choice(self.fnames, p=self.probs)
@@ -190,14 +209,20 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
             start = np.random.randint(0, max_start + 1)
 
             # load the chunk and insert it into the batch
-            chunk = self.load_chunk(fname, start, chunk_size)
+            wf_chunk, param_chunk = self.load_chunk(fname, start, chunk_size)
+
             batch_start = i * self.chunk_size
             batch_end = batch_start + chunk_size
 
-            for i, channel in enumerate(self.channels):
-                batch[batch_start:batch_end, i, :] = chunk[channel]
+            for k in self.param_keys:
+                params_buf[k][batch_start:batch_end] = param_chunk[k]
 
-        return torch.tensor(batch)
+            for j, channel in enumerate(self.channels):
+                batch[batch_start:batch_end, j, :] = wf_chunk[channel]
+
+        waveforms = torch.tensor(batch)
+        params = {k: torch.tensor(v) for k, v in params_buf.items()}
+        return waveforms, params
 
     def __iter__(self):
         for _ in range(self.batches_per_epoch):
@@ -227,7 +252,7 @@ class ChunkedWaveformDataset(torch.utils.data.IterableDataset):
 
     def __init__(
         self,
-        chunk_it: Iterable,
+        chunk_it: Sequence,
         batch_size: int,
         batches_per_chunk: int,
     ) -> None:
@@ -241,17 +266,27 @@ class ChunkedWaveformDataset(torch.utils.data.IterableDataset):
 
     def __iter__(self):
         it = iter(self.chunk_it)
-        [chunk] = next(it)
 
-        num_waveforms, _, _ = chunk.shape
+        def _next(it):
+            [waveform_chunk], param_dict_chunk = next(it)
+            return waveform_chunk, {
+                k: v[0] for k, v in param_dict_chunk.items()
+            }
+
+        waveform_chunk, param_chunk = _next(it)
+        num_waveforms, _, _ = waveform_chunk.shape
+
         while True:
             # generate batches from the current chunk
             for _ in range(self.batches_per_chunk):
                 idx = torch.randperm(num_waveforms)[: self.batch_size]
-                yield chunk[idx]
+                yield (
+                    waveform_chunk[idx],
+                    {k: v[idx] for k, v in param_chunk.items()},
+                )
 
             try:
-                [chunk] = next(it)
+                waveform_chunk, param_chunk = _next(it)
             except StopIteration:
                 break
-            num_waveforms, _, _ = chunk.shape
+            num_waveforms, _, _ = waveform_chunk.shape

--- a/projects/train/train/data/waveforms/sampler.py
+++ b/projects/train/train/data/waveforms/sampler.py
@@ -1,6 +1,8 @@
+from dataclasses import fields
 from pathlib import Path
 from typing import List
 
+import numpy as np
 import torch
 from utils import x_per_y
 
@@ -9,6 +11,7 @@ from ledger.injections import WaveformSet, waveform_class_factory
 Distribution = torch.distributions.Distribution
 
 
+# TODO: Make this class ABC?
 class WaveformSampler(torch.nn.Module):
     """
     Base object defining methods that waveform producing classes
@@ -60,15 +63,33 @@ class WaveformSampler(torch.nn.Module):
 
     # Assuming that we're going to be loading validation waveforms
     # from disk for now, so this function can be defined here.
-    def get_val_waveforms(self, world_size, rank):
-        """
-        Returns validation waveforms for this device
+    def get_val_waveforms(
+        self, world_size, rank
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        """Returns validation waveforms and injection parameters
+        for this device.
+
+        Returns:
+            Tuple of (waveforms, params) where waveforms has shape
+            ``(N, num_ifos, T)`` and params is a dict mapping each
+            scalar injection parameter name to a tensor of
+            shape ``(N, ...)``.
         """
         start, stop = self.get_slice_bounds(
             self.num_val_waveforms, world_size, rank
         )
         waveform_set = self.waveform_set_cls.read(self.val_waveform_file)
-        return torch.Tensor(waveform_set.waveforms[start:stop])
+        waveforms = torch.Tensor(waveform_set.waveforms[start:stop])
+
+        params: dict[str, torch.Tensor] = {}
+        for f in fields(waveform_set):
+            if f.metadata.get("kind") != "parameter":
+                continue
+            val = getattr(waveform_set, f.name)
+            if isinstance(val, np.ndarray):
+                params[f.name] = torch.from_numpy(val[start:stop])
+
+        return waveforms, params
 
     def get_test_waveforms(self):
         raise NotImplementedError

--- a/projects/train/train/model/base.py
+++ b/projects/train/train/model/base.py
@@ -170,7 +170,7 @@ class AframeBase(pl.LightningModule):
         return loss
 
     def validation_step(self, batch, _) -> None:
-        shift, X_bg, X_inj = batch
+        shift, X_bg, X_inj, params = batch
 
         y_bg = self.score(X_bg)
 

--- a/projects/train/train/model/supervised.py
+++ b/projects/train/train/model/supervised.py
@@ -14,8 +14,8 @@ class SupervisedAframe(AframeBase):
     def forward(self, X):
         return self.model(X)
 
-    def train_step(self, batch: tuple[Tensor, Tensor]) -> Tensor:
-        X, y = batch
+    def train_step(self, batch: tuple[Tensor, Tensor, dict]) -> Tensor:
+        X, y, params = batch
         y_hat = self(X)
         return torch.nn.functional.binary_cross_entropy_with_logits(y_hat, y)
 
@@ -33,13 +33,13 @@ class SupervisedMultiModalAframe(SupervisedAframe):
     def score(self, X, X_fft):
         return self(X, X_fft)
 
-    def train_step(self, batch: tuple[Tensor, Tensor]) -> Tensor:
-        (X, X_fft), y = batch
+    def train_step(self, batch: tuple[Tensor, Tensor, dict]) -> Tensor:
+        (X, X_fft), y, params = batch
         y_hat = self(X, X_fft)
         return torch.nn.functional.binary_cross_entropy_with_logits(y_hat, y)
 
     def validation_step(self, batch, _) -> None:
-        shift, (X_bg, X_bg_fft), (X_inj, X_inj_fft) = batch
+        shift, (X_bg, X_bg_fft), (X_inj, X_inj_fft), params = batch
 
         y_bg = self.score(X_bg, X_bg_fft)
 
@@ -102,9 +102,9 @@ class SupervisedTimeSpectrogramAframe(SupervisedAframe):
         return self(X, X_spec)
 
     def train_step(
-        self, batch: tuple[tuple[Tensor, Tensor], Tensor]
+        self, batch: tuple[tuple[Tensor, Tensor], Tensor, dict]
     ) -> Tensor | dict[str, Tensor]:
-        (X, X_spec), y = batch
+        (X, X_spec), y, params = batch
         y_hat_X, y_hat_X_spec = self(X, X_spec)
         loss_X = torch.nn.functional.binary_cross_entropy_with_logits(
             y_hat_X, y
@@ -124,7 +124,7 @@ class SupervisedTimeSpectrogramAframe(SupervisedAframe):
         )
 
     def validation_step(self, batch, _) -> None:
-        shift, (X_bg, X_bg_spec), (X_fg, X_fg_spec) = batch
+        shift, (X_bg, X_bg_spec), (X_fg, X_fg_spec), params = batch
 
         y_bg_X, y_bg_spec = self.score(X_bg, X_bg_spec)
         y_bg = (self.val_X_coeff * y_bg_X) + (


### PR DESCRIPTION
This PR wires through the parameters of injected waveforms (from disk or the sampler) through the dataloader and exposes the parameters as the third item in the `batch` tuple. During training `batch` becomes `(X, y, params)` and during validation `(X_bg, X_inj, y, params)`. For samples where no waveform is injected (or they are corrupted) the respective parameters are set to NaN values.

To simplify the dataflow this PR implements one other minor change: `inject` is always called with the `waveforms` argument set. None is not allowed anymore. `def on_after_batch_transfer(self, batch, _):` will now sample waveforms if they are not loaded from disk.

This PR is useful for possible regression or combined regression/classification tasks and also for the classification task for logging parameter dependent metrics such as e.g.:  SNR vs. detection efficiency etc.