### PR TITLE
Regression & Multitask

### DIFF
--- a/libs/architectures/architectures/__init__.py
+++ b/libs/architectures/architectures/__init__.py
@@ -1,4 +1,10 @@
 from .base import Architecture
+from .regression import (
+    MultiTaskArchitecture,
+    MultiTaskTimeDomainResNet,
+    RegressionArchitecture,
+    RegressionTimeDomainResNet,
+)
 from .supervised import (
     SupervisedArchitecture,
     SupervisedFrequencyDomainResNet,

--- a/libs/architectures/architectures/regression.py
+++ b/libs/architectures/architectures/regression.py
@@ -1,0 +1,120 @@
+from typing import Literal, Optional
+
+import torch
+from ml4gw.nn.resnet.resnet_1d import NormLayer, ResNet1D
+
+from architectures import Architecture
+
+
+class RegressionArchitecture(Architecture):
+    """
+    Base class for regression architectures.
+    Forward pass returns a tensor of shape ``(N, num_params)``.
+    """
+
+    def forward(self, X: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+
+class MultiTaskArchitecture(Architecture):
+    """
+    Base class for multi-task architectures.
+    Forward pass returns ``(logits, param_estimates)`` where
+    ``logits`` has shape ``(N, 1)`` and ``param_estimates``
+    has shape ``(N, num_params)``.
+    """
+
+    def forward(
+        self, X: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError
+
+
+class RegressionTimeDomainResNet(ResNet1D, RegressionArchitecture):
+    """
+    ResNet1D backbone for injection parameter regression.
+    Outputs a tensor of shape ``(N, num_params)``.
+
+    Args:
+        num_params:
+            Number of parameters to regress. Must match the length
+            of ``param_names`` in the model config.
+    """
+
+    def __init__(
+        self,
+        num_ifos: int,
+        sample_rate: float,
+        kernel_length: float,
+        num_params: int,
+        layers: list[int],
+        kernel_size: int = 3,
+        zero_init_residual: bool = False,
+        groups: int = 1,
+        width_per_group: int = 64,
+        stride_type: Optional[list[Literal["stride", "dilation"]]] = None,
+        norm_layer: Optional[NormLayer] = None,
+    ) -> None:
+        super().__init__(
+            num_ifos,
+            layers=layers,
+            classes=num_params,
+            kernel_size=kernel_size,
+            zero_init_residual=zero_init_residual,
+            groups=groups,
+            width_per_group=width_per_group,
+            stride_type=stride_type,
+            norm_layer=norm_layer,
+        )
+
+
+class MultiTaskTimeDomainResNet(MultiTaskArchitecture):
+    """
+    Shared ResNet1D backbone with separate classification and regression heads.
+    Returns ``(logits, param_estimates)`` where logits has shape ``(N, 1)``
+    and param_estimates has shape ``(N, num_params)``.
+
+    Args:
+        embedding_dim:
+            Dimensionality of the shared backbone's output embedding,
+            i.e. the input size to both heads.
+        num_params:
+            Number of parameters to regress. Must match the length
+            of ``param_names`` in the model config.
+    """
+
+    def __init__(
+        self,
+        num_ifos: int,
+        sample_rate: float,
+        kernel_length: float,
+        num_params: int,
+        layers: list[int],
+        embedding_dim: int = 512,
+        kernel_size: int = 3,
+        zero_init_residual: bool = False,
+        groups: int = 1,
+        width_per_group: int = 64,
+        stride_type: Optional[list[Literal["stride", "dilation"]]] = None,
+        norm_layer: Optional[NormLayer] = None,
+    ) -> None:
+        super().__init__()
+        self.backbone = ResNet1D(
+            num_ifos,
+            layers=layers,
+            classes=embedding_dim,
+            kernel_size=kernel_size,
+            zero_init_residual=zero_init_residual,
+            groups=groups,
+            width_per_group=width_per_group,
+            stride_type=stride_type,
+            norm_layer=norm_layer,
+        )
+        self.clf_head = torch.nn.Linear(embedding_dim, 1)
+        self.reg_head = torch.nn.Linear(embedding_dim, num_params)
+
+    def forward(
+        self, X: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        h = self.backbone(X)
+        return self.clf_head(h), self.reg_head(h)

--- a/projects/train/configs/regression/multitask.yaml
+++ b/projects/train/configs/regression/multitask.yaml
@@ -49,8 +49,8 @@ model:
 data:
   class_path: train.data.supervised.TimeDomainSupervisedAframeDataset
   init_args:
-    background_dir: /home/barmstrong/aframe_new/data/bns/background_data
-    waveforms_dir: /home/barmstrong/aframe_new/data/bns/aframe_train/
+    background_dir: data/bns/background_data
+    waveforms_dir: data/bns/aframe_train/
     ifos: [H1, L1]
     sample_rate: 2048
 
@@ -82,10 +82,10 @@ data:
     snr_sampler:
       class_path: train.augmentations.SnrSampler
       init_args:
-        max_min_snr: 12.0
+        alpha: -3
+        max_min_snr: 8.0
         min_min_snr: 4.0
         max_snr: 100.0
-        alpha: 1.0
         decay_steps: 10000
         # distribution_type: uniform
 
@@ -97,8 +97,8 @@ data:
       init_args:
         ifos: [H1, L1]
         sample_rate: 2048
-        val_waveform_file: /home/barmstrong/aframe_new/data/bns/aframe_train/val_waveforms.hdf5
-        training_waveform_path: /home/barmstrong/aframe_new/data/bns/uniform_chirp_mass_waveforms/training_waveforms.hdf5
+        val_waveform_file: data/bns/aframe_train/val_waveforms.hdf5
+        training_waveform_path: data/bns/uniform_chirp_mass_waveforms/training_waveforms.hdf5
 
     dec:
       class_path: ml4gw.distributions.Cosine

--- a/projects/train/configs/regression/multitask.yaml
+++ b/projects/train/configs/regression/multitask.yaml
@@ -1,0 +1,146 @@
+# Multi-task training config.
+# Jointly optimises binary classification (AUROC) and parameter regression.
+#
+# The shared ResNet backbone feeds into two heads:
+#   - classification head: single logit for detection
+#   - regression head:     num_params outputs for parameter estimation
+#
+# Validation uses the standard AUROC metric on the classification head,
+# so model selection and early stopping work the same as for classification.
+#
+# IMPORTANT: param_names and num_params must be consistent.
+
+model:
+  class_path: train.model.SupervisedMultiTaskAframe
+  init_args:
+    arch:
+      class_path: architectures.MultiTaskTimeDomainResNet
+      init_args:
+        layers: [3, 4, 6, 3]
+        # Shared backbone output dimension feeding both heads
+        embedding_dim: 512
+        # Must equal len(param_names) below
+        num_params: 1
+        norm_layer:
+          class_path: ml4gw.nn.norm.GroupNorm1DGetter
+          init_args:
+            groups: 16
+
+    metric:
+      class_path: train.metrics.TimeSlideAUROC
+      init_args:
+        max_fpr: 1e-3
+        pool_length: 8
+
+    # Update to match the parameters available in your waveform files.
+    # Extrinsic params (dec, psi, phi, snr) are always available.
+    param_names:
+      - chirp_mass
+
+    # Weight applied to the regression loss before summing with BCE.
+    # Tune this to balance the two tasks.
+    regression_weight: 1.0
+
+    # optimization
+    learning_rate: 1e-3
+    pct_lr_ramp: 0.115
+    weight_decay: 1e-4
+
+data:
+  class_path: train.data.supervised.TimeDomainSupervisedAframeDataset
+  init_args:
+    background_dir: /home/barmstrong/aframe_new/data/bns/background_data
+    waveforms_dir: /home/barmstrong/aframe_new/data/bns/aframe_train/
+    ifos: [H1, L1]
+    sample_rate: 2048
+
+    kernel_length: 2.0
+    left_pad: 1.75
+    right_pad: 0
+
+    batch_size: 256
+    batches_per_epoch: 1000
+    chunk_size: 10000
+    chunks_per_epoch: 10
+    num_files_per_batch: 4
+
+    fduration: 2.0
+    fftlength: 2.0
+    psd_length: 20
+    highpass: 20
+    lowpass: 1024
+
+    waveform_prob: 0.5
+    swap_prob: 0.014
+    mute_prob: 0.055
+    max_num_workers: 16
+
+    valid_stride: 0.5
+    num_valid_views: 5
+    valid_livetime: 57600
+
+    snr_sampler:
+      class_path: train.augmentations.SnrSampler
+      init_args:
+        max_min_snr: 12.0
+        min_min_snr: 4.0
+        max_snr: 100.0
+        alpha: 1.0
+        decay_steps: 10000
+        # distribution_type: uniform
+
+    param_transforms:
+      - class_path: train.transforms.ChirpMass
+
+    waveform_sampler:
+      class_path: train.data.waveforms.WaveformLoader
+      init_args:
+        ifos: [H1, L1]
+        sample_rate: 2048
+        val_waveform_file: /home/barmstrong/aframe_new/data/bns/aframe_train/val_waveforms.hdf5
+        training_waveform_path: /home/barmstrong/aframe_new/data/bns/uniform_chirp_mass_waveforms/training_waveforms.hdf5
+
+    dec:
+      class_path: ml4gw.distributions.Cosine
+    psi:
+      class_path: torch.distributions.Uniform
+      init_args:
+        low: 0
+        high: 3.14159
+        validate_args: false
+    phi:
+      class_path: torch.distributions.Uniform
+      init_args:
+        low: -3.14159
+        high: 3.14159
+        validate_args: false
+
+trainer:
+  logger:
+    - class_path: train.callbacks.AframeWandbLogger
+      init_args:
+        name: "aframe_multitask"
+        save_dir: outputs
+        project: "aframe"
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        monitor: "validation/TimeSlideAUROC"
+        mode: "max"
+        patience: 50
+    - class_path: train.callbacks.ModelCheckpoint
+      init_args:
+        monitor: "validation/TimeSlideAUROC"
+        mode: "max"
+        save_top_k: 1
+        save_last: true
+        auto_insert_metric_name: false
+    - class_path: train.callbacks.SaveAugmentedBatch
+
+  accelerator: auto
+  max_epochs: 200
+  check_val_every_n_epoch: 1
+  log_every_n_steps: 25
+  enable_progress_bar: true
+  benchmark: true

--- a/projects/train/configs/regression/regression.yaml
+++ b/projects/train/configs/regression/regression.yaml
@@ -1,0 +1,136 @@
+# Regression-only training config.
+# Predicts injection parameters directly from whitened strain.
+#
+# Key differences from the classification configs:
+#   - waveform_prob: 1.0  (every sample is injected)
+#   - num_valid_views: 1  (multi-view averaging is not useful for regression)
+#   - No AUROC metric; EarlyStopping monitors per-parameter MAE instead.
+#
+# IMPORTANT: param_names and num_params must be consistent. Set them to the
+# parameter names present in the "parameters" group of your waveform HDF5
+# files plus any extrinsic params added by inject() (dec, psi, phi, snr).
+
+model:
+  class_path: train.model.SupervisedRegressionAframe
+  init_args:
+    arch:
+      class_path: architectures.RegressionTimeDomainResNet
+      init_args:
+        layers: [3, 4, 6, 3]
+        # Must equal len(param_names) below
+        num_params: 1
+        norm_layer:
+          class_path: ml4gw.nn.norm.GroupNorm1DGetter
+          init_args:
+            groups: 16
+
+    # Update to match the parameters available in your waveform files.
+    # Extrinsic params (dec, psi, phi, snr) are always available.
+    param_names:
+      - chirp_mass
+
+    # optimization
+    learning_rate: 1e-3
+    pct_lr_ramp: 0.115
+    weight_decay: 1e-4
+
+data:
+  class_path: train.data.supervised.TimeDomainSupervisedAframeDataset
+  init_args:
+    background_dir: /home/barmstrong/aframe_new/data/bns/background_data
+    waveforms_dir: /home/barmstrong/aframe_new/data/bns/aframe_train/
+    ifos: [H1, L1]
+    sample_rate: 2048
+
+    kernel_length: 2.0
+    left_pad: 1.75
+    right_pad: 0
+
+    batch_size: 256
+    batches_per_epoch: 1000
+    chunk_size: 10000
+    chunks_per_epoch: 10
+    num_files_per_batch: 4
+
+    fduration: 2.0
+    fftlength: 2.0
+    psd_length: 20
+    highpass: 20
+    lowpass: 1024
+
+    # Inject into every sample so the regression loss is never sparse.
+    waveform_prob: 1.0
+    swap_prob: 0.0
+    mute_prob: 0.0
+    max_num_workers: 16
+
+    valid_stride: 0.5
+    num_valid_views: 5
+    valid_livetime: 57600
+
+    snr_sampler:
+      class_path: train.augmentations.SnrSampler
+      init_args:
+        max_min_snr: 12.0
+        min_min_snr: 4.0
+        max_snr: 100.0
+        alpha: 1.0
+        decay_steps: 10000
+        # distribution_type: uniform
+
+    param_transforms:
+      - class_path: train.transforms.ChirpMass
+
+    waveform_sampler:
+      class_path: train.data.waveforms.WaveformLoader
+      init_args:
+        ifos: [H1, L1]
+        sample_rate: 2048
+        val_waveform_file: /home/barmstrong/aframe_new/data/bns/aframe_train/val_waveforms.hdf5
+        training_waveform_path: /home/barmstrong/aframe_new/data/bns/uniform_chirp_mass_waveforms/training_waveforms.hdf5
+
+    dec:
+      class_path: ml4gw.distributions.Cosine
+    psi:
+      class_path: torch.distributions.Uniform
+      init_args:
+        low: 0
+        high: 3.14159
+        validate_args: false
+    phi:
+      class_path: torch.distributions.Uniform
+      init_args:
+        low: -3.14159
+        high: 3.14159
+        validate_args: false
+
+trainer:
+  logger:
+    - class_path: train.callbacks.AframeWandbLogger
+      init_args:
+        name: "aframe_multitask"
+        save_dir: outputs
+        project: "aframe"
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        # Monitor the first param's MAE; adjust to taste.
+        monitor: "validation/mae_chirp_mass"
+        mode: "min"
+        patience: 50
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: "validation/mae_chirp_mass"
+        mode: "min"
+        save_top_k: 1
+        save_last: true
+        auto_insert_metric_name: false
+    - class_path: train.callbacks.SaveAugmentedBatch
+
+  accelerator: auto
+  max_epochs: 200
+  check_val_every_n_epoch: 1
+  log_every_n_steps: 20
+  enable_progress_bar: true
+  benchmark: true

--- a/projects/train/configs/regression/regression.yaml
+++ b/projects/train/configs/regression/regression.yaml
@@ -37,8 +37,8 @@ model:
 data:
   class_path: train.data.supervised.TimeDomainSupervisedAframeDataset
   init_args:
-    background_dir: /home/barmstrong/aframe_new/data/bns/background_data
-    waveforms_dir: /home/barmstrong/aframe_new/data/bns/aframe_train/
+    background_dir: data/bns/background_data
+    waveforms_dir: data/bns/aframe_train/
     ifos: [H1, L1]
     sample_rate: 2048
 
@@ -71,10 +71,10 @@ data:
     snr_sampler:
       class_path: train.augmentations.SnrSampler
       init_args:
-        max_min_snr: 12.0
+        alpha: -3
+        max_min_snr: 8.0
         min_min_snr: 4.0
         max_snr: 100.0
-        alpha: 1.0
         decay_steps: 10000
         # distribution_type: uniform
 
@@ -86,8 +86,8 @@ data:
       init_args:
         ifos: [H1, L1]
         sample_rate: 2048
-        val_waveform_file: /home/barmstrong/aframe_new/data/bns/aframe_train/val_waveforms.hdf5
-        training_waveform_path: /home/barmstrong/aframe_new/data/bns/uniform_chirp_mass_waveforms/training_waveforms.hdf5
+        val_waveform_file: data/bns/aframe_train/val_waveforms.hdf5
+        training_waveform_path: data/bns/uniform_chirp_mass_waveforms/training_waveforms.hdf5
 
     dec:
       class_path: ml4gw.distributions.Cosine
@@ -108,7 +108,7 @@ trainer:
   logger:
     - class_path: train.callbacks.AframeWandbLogger
       init_args:
-        name: "aframe_multitask"
+        name: "aframe_regression"
         save_dir: outputs
         project: "aframe"
 

--- a/projects/train/tests/data/conftest.py
+++ b/projects/train/tests/data/conftest.py
@@ -1,0 +1,237 @@
+"""Shared fixtures and helpers for data tests."""
+
+import logging
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+import torch
+from ledger.injections import (
+    WaveformPolarizationSet,
+    WaveformSet,
+    waveform_class_factory,
+)
+
+from train.metrics import get_timeslides
+
+# ---------------------------------------------------------------------------
+# Shared constants
+# ---------------------------------------------------------------------------
+SAMPLE_RATE = 2048
+IFOS = ["H1", "L1"]
+KERNEL_LENGTH = 2.0
+FDURATION = 1.0
+PSD_LENGTH = 4.0
+SAMPLE_LENGTH = PSD_LENGTH + KERNEL_LENGTH + FDURATION  # 7.0 s
+WAVEFORM_DURATION = 8.0
+WAVEFORM_SAMPLES = int(WAVEFORM_DURATION * SAMPLE_RATE)
+WAVEFORM_RIGHT_PAD = 0.0
+BATCH_SIZE = 8
+VALID_LIVETIME = 20.0
+VALID_STRIDE = 1.0
+MIN_VALID_DURATION = 25.0
+BG_DURATION = 30
+BG_SAMPLES = BG_DURATION * SAMPLE_RATE  # 3840
+
+# Derived geometry (left_pad=right_pad=0 in hparams)
+FILTER_SIZE = int(FDURATION * SAMPLE_RATE)  # 128
+LEFT_PAD_SIZE = FILTER_SIZE // 2  # 64
+RIGHT_PAD_SIZE = FILTER_SIZE // 2  # 64
+# "unwhitened kernel" = kernel_length*sr + fduration*sr
+KERNEL_SIZE = int(KERNEL_LENGTH * SAMPLE_RATE) + FILTER_SIZE  # 384
+# waveform length after slice_waveforms
+SLICED_SAMPLES = 2 * KERNEL_SIZE - LEFT_PAD_SIZE - RIGHT_PAD_SIZE  # 640
+
+
+# ---------------------------------------------------------------------------
+# Low-level file builders
+# ---------------------------------------------------------------------------
+
+
+def _bilby_param_arrays(n: int) -> dict:
+    """Return zeroed arrays for every BilbyParameterSet field."""
+    names = [
+        "mass_1",
+        "mass_2",
+        "a_1",
+        "a_2",
+        "tilt_1",
+        "tilt_2",
+        "phi_12",
+        "phi_jl",
+        "ra",
+        "dec",
+        "redshift",
+        "psi",
+        "theta_jn",
+        "phase",
+    ]
+    return {
+        k: np.ones(n, dtype=np.float64)
+        if k in ("mass_1", "mass_2")
+        else np.zeros(n, dtype=np.float64)
+        for k in names
+    }
+
+
+def make_background_dir(tmp_path: Path) -> Path:
+    """Create a minimal background directory with train + val HDF5 files."""
+    bg_dir = tmp_path / "background"
+    bg_dir.mkdir(exist_ok=True)
+    rng = np.random.default_rng(0)
+    for stem in ["train-30", "val-30"]:
+        with h5py.File(bg_dir / f"{stem}.hdf5", "w") as f:
+            for ifo in IFOS:
+                data = rng.standard_normal(BG_SAMPLES).astype(np.float32)
+                dset = f.create_dataset(ifo, data=data)
+                dset.attrs["dx"] = 1.0 / SAMPLE_RATE
+    return tmp_path
+
+
+def make_val_waveform_file(tmp_path: Path, n: int = 20) -> Path:
+    """Write a WaveformSet (val) HDF5 file and return its path."""
+    T = WAVEFORM_SAMPLES
+    rng = np.random.default_rng(1)
+    WS = waveform_class_factory(IFOS, WaveformSet, "WaveformSet")
+    ifo_fields = {
+        ifo.lower(): rng.standard_normal((n, T)).astype(np.float32)
+        for ifo in IFOS
+    }
+    params = _bilby_param_arrays(n)
+    wset = WS(
+        **ifo_fields,
+        **params,
+        snr=np.ones(n),
+        ifo_snrs=np.ones((n, len(IFOS))),
+        ifos=IFOS,
+        sample_rate=SAMPLE_RATE,
+        duration=WAVEFORM_DURATION,
+        right_pad=WAVEFORM_RIGHT_PAD,
+        num_injections=n,
+    )
+    path = tmp_path / "val_waveforms.hdf5"
+    wset.write(path)
+    return path
+
+
+def make_training_waveform_file(tmp_path: Path, n: int = 100) -> Path:
+    """Write a WaveformPolarizationSet (training) HDF5 file and return its
+    path."""
+    T = WAVEFORM_SAMPLES
+    rng = np.random.default_rng(2)
+    params = _bilby_param_arrays(n)
+    wps = WaveformPolarizationSet(
+        cross=rng.standard_normal((n, T)).astype(np.float32),
+        plus=rng.standard_normal((n, T)).astype(np.float32),
+        **params,
+        sample_rate=SAMPLE_RATE,
+        duration=WAVEFORM_DURATION,
+        right_pad=WAVEFORM_RIGHT_PAD,
+        num_injections=n,
+    )
+    wf_dir = tmp_path / "training_waveforms"
+    wf_dir.mkdir(exist_ok=True)
+    path = wf_dir / "waveforms.hdf5"
+    wps.write(path)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# pytest fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def data_dir(tmp_path):
+    """Root temp directory with background/ subfolder populated."""
+    return make_background_dir(tmp_path)
+
+
+@pytest.fixture()
+def val_waveform_file(data_dir):
+    return make_val_waveform_file(data_dir)
+
+
+@pytest.fixture()
+def training_waveform_file(data_dir):
+    return make_training_waveform_file(data_dir)
+
+
+# ---------------------------------------------------------------------------
+# Dataset construction helpers
+# ---------------------------------------------------------------------------
+
+
+def base_dataset_kwargs(data_dir, waveform_sampler) -> dict:
+    """Common __init__ kwargs for TimeDomainSupervisedAframeDataset."""
+    return {
+        "background_dir": str(data_dir),
+        "waveforms_dir": str(data_dir),
+        "ifos": IFOS,
+        "sample_rate": SAMPLE_RATE,
+        "dec": torch.distributions.Uniform(-1.0, 1.0),
+        "psi": torch.distributions.Uniform(0.0, float(np.pi)),
+        "phi": torch.distributions.Uniform(0.0, 2.0 * float(np.pi)),
+        "batches_per_epoch": 4,
+        "num_files_per_batch": 1,
+        "waveform_sampler": waveform_sampler,
+        "batch_size": BATCH_SIZE,
+        "kernel_length": KERNEL_LENGTH,
+        "fduration": FDURATION,
+        "psd_length": PSD_LENGTH,
+        "waveform_prob": 1.0,
+        "left_pad": 0.0,
+        "right_pad": 0.0,
+        "snr_sampler": torch.distributions.Uniform(8.0, 20.0),
+        "valid_stride": VALID_STRIDE,
+        "min_valid_duration": MIN_VALID_DURATION,
+        "valid_livetime": VALID_LIVETIME,
+        "swap_prob": 0.1,
+        "mute_prob": 0.05,
+    }
+
+
+def setup_dataset_manually(dataset) -> None:
+    """
+    Initialise a dataset's runtime attributes without requiring a
+    Lightning Trainer (needed for setup() + transforms_to_device()).
+    """
+    dataset._logger = logging.getLogger("test")
+    dataset.train_fnames, dataset.valid_fnames = dataset.train_val_split()
+
+    val_bg = dataset.load_val_background(dataset.valid_fnames)
+    dataset.timeslides, dataset.valid_loader_length = get_timeslides(
+        val_bg,
+        dataset.hparams.valid_livetime,
+        dataset.hparams.sample_rate,
+        dataset.sample_length,
+        dataset.hparams.valid_stride,
+        dataset.val_batch_size,
+    )
+    dataset.val_waveforms, dataset.val_params = (
+        dataset.waveform_sampler.get_val_waveforms(1, 0)
+    )
+    dataset.build_transforms()
+    # skip transforms_to_device(): no trainer / GPU required in unit tests
+
+
+def make_synthetic_X(batch_size: int = BATCH_SIZE) -> torch.Tensor:
+    """Background tensor of the shape expected by inject()."""
+    n_samples = int(SAMPLE_LENGTH * SAMPLE_RATE)
+    return torch.randn(batch_size, len(IFOS), n_samples)
+
+
+def make_synthetic_waveforms(
+    n: int = 32,
+    *,
+    sliced: bool,
+) -> torch.Tensor:
+    """
+    Waveform tensor (cross/plus) for inject().
+
+    sliced=True  → pre-sliced to SLICED_SAMPLES (disk-loader mode).
+    sliced=False → full WAVEFORM_SAMPLES length (generator mode).
+    """
+    T = SLICED_SAMPLES if sliced else WAVEFORM_SAMPLES
+    return torch.randn(n, 2, T)

--- a/projects/train/tests/data/test_chunked_waveform_dataset.py
+++ b/projects/train/tests/data/test_chunked_waveform_dataset.py
@@ -1,0 +1,115 @@
+"""
+Unit tests for ChunkedWaveformDataset.
+"""
+
+import torch
+
+from train.data.waveforms.loader import ChunkedWaveformDataset
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_chunk(n: int, T: int, num_channels: int = 2) -> tuple:
+    """Return a (waveforms, params) chunk like Hdf5WaveformLoader produces."""
+    waveforms = torch.randn(n, num_channels, T)
+    params = {"mass_1": torch.arange(n, dtype=torch.float32)}
+    return waveforms, params
+
+
+def _finite_loader(chunks: list[tuple]) -> list:
+    """
+    Simulate what ChunkedWaveformDataset receives from a DataLoader wrapping
+    Hdf5WaveformLoader.  DataLoader with default batch_size=1 collates each
+    yielded (waveforms, params) item into a tensor of shape (1, N, C, T) for
+    waveforms and (1, N) for each param, so that _next(it) can unpack them as:
+        [waveform_chunk], param_dict_chunk = next(it)
+    and then waveform_chunk = tensor[0] of shape (N, C, T).
+    """
+    return [
+        (wf.unsqueeze(0), {k: v.unsqueeze(0) for k, v in p.items()})
+        for wf, p in chunks
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Yielded tuples have consistent batch dimensions
+# ---------------------------------------------------------------------------
+def test_consistent_batch_dimensions():
+    batch_size = 4
+    n_chunk = 20
+    T = 128
+    chunks = _finite_loader([_make_chunk(n_chunk, T)])
+    dataset = ChunkedWaveformDataset(
+        chunks, batch_size=batch_size, batches_per_chunk=3
+    )
+
+    for wf_batch, params_dict in dataset:
+        assert wf_batch.shape[0] == batch_size
+        for key, val in params_dict.items():
+            assert val.shape[0] == batch_size, (
+                f"params['{key}'] batch dim {val.shape[0]} != {batch_size}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Params are indexed with the same permutation as waveforms
+# ---------------------------------------------------------------------------
+def test_params_indexed_same_as_waveforms():
+    """
+    Waveform identity is encoded in the first time-sample of channel 0
+    (wf[i, 0, 0] = i) and also in params['idx'][i] = i.
+    After sampling, both must agree on which waveforms were selected.
+    """
+    batch_size = 5
+    n_chunk = 30
+    T = 64
+
+    waveforms = torch.zeros(n_chunk, 2, T)
+    waveforms[:, 0, 0] = torch.arange(n_chunk, dtype=torch.float32)
+    params = {"idx": torch.arange(n_chunk, dtype=torch.float32)}
+
+    chunks = _finite_loader([(waveforms, params)])
+    dataset = ChunkedWaveformDataset(
+        chunks, batch_size=batch_size, batches_per_chunk=1
+    )
+
+    wf_batch, params_dict = next(iter(dataset))
+
+    # The identity stored in waveform[i, 0, 0] must match params['idx'][i]
+    wf_identity = wf_batch[:, 0, 0]
+    param_identity = params_dict["idx"]
+    assert torch.equal(wf_identity, param_identity), (
+        "Waveform and param identities differ "
+        "— different permutations were used"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dataset exhausts cleanly on StopIteration
+# ---------------------------------------------------------------------------
+def test_exhausts_cleanly():
+    batch_size = 4
+    n_chunk = 20
+    T = 64
+    batches_per_chunk = 3
+    num_chunks = 2
+
+    chunks = _finite_loader(
+        [_make_chunk(n_chunk, T) for _ in range(num_chunks)]
+    )
+    dataset = ChunkedWaveformDataset(
+        chunks, batch_size=batch_size, batches_per_chunk=batches_per_chunk
+    )
+
+    count = 0
+    for _ in dataset:
+        count += 1
+
+    expected = num_chunks * batches_per_chunk
+    assert count == expected, (
+        f"Expected {expected} batches from {num_chunks} chunks × "
+        f"{batches_per_chunk} batches/chunk; got {count}"
+    )

--- a/projects/train/tests/data/test_e2e_disk_loader.py
+++ b/projects/train/tests/data/test_e2e_disk_loader.py
@@ -1,0 +1,92 @@
+"""
+End-to-end integration test — disk-loader path.
+
+Wires TimeDomainSupervisedAframeDataset + WaveformLoader and calls inject()
+with synthetic background and pre-sliced waveforms, asserting that parameter
+dicts are correctly shaped, keyed, and have NaN exactly where labels == 0.
+"""
+
+import pytest
+import torch
+
+from train.data.supervised.time_domain import TimeDomainSupervisedAframeDataset
+from train.data.waveforms.loader import WaveformLoader
+
+from conftest import (
+    BATCH_SIZE,
+    IFOS,
+    SAMPLE_RATE,
+    base_dataset_kwargs,
+    make_synthetic_X,
+    make_synthetic_waveforms,
+    setup_dataset_manually,
+)
+
+EXTRINSIC_KEYS = {"dec", "psi", "phi", "snr"}
+
+
+@pytest.fixture()
+def disk_loader_dataset(data_dir, val_waveform_file, training_waveform_file):
+    sampler = WaveformLoader(
+        ifos=IFOS,
+        sample_rate=SAMPLE_RATE,
+        val_waveform_file=val_waveform_file,
+        training_waveform_path=training_waveform_file,
+    )
+    dataset = TimeDomainSupervisedAframeDataset(
+        **base_dataset_kwargs(data_dir, sampler)
+    )
+    setup_dataset_manually(dataset)
+    return dataset
+
+
+@pytest.fixture()
+def inject_outputs(disk_loader_dataset):
+    """
+    Run one inject() call and return (X_out, y, params_out).
+
+    Waveforms are pre-sliced (SLICED_SAMPLES) to match what
+    on_before_batch_transfer would produce for the disk-loader path.
+    """
+    X = make_synthetic_X()
+    waveforms = make_synthetic_waveforms(n=32, sliced=True)
+    params = {"mass_1": torch.arange(32, dtype=torch.float32)}
+    return disk_loader_dataset.inject(X=X, waveforms=waveforms, params=params)
+
+
+def test_param_keys_and_shape(inject_outputs):
+    _, _, params_out = inject_outputs
+    for key in EXTRINSIC_KEYS:
+        assert key in params_out, f"Missing expected key '{key}'"
+    for key, val in params_out.items():
+        assert val.shape == (BATCH_SIZE,), (
+            f"params_out['{key}'] has shape {val.shape},"
+            f" expected ({BATCH_SIZE},)"
+        )
+
+
+def test_nan_matches_labels(inject_outputs):
+    _, y, params_out = inject_outputs
+    not_injected = y.squeeze() == 0
+    for key, val in params_out.items():
+        nan_mask = torch.isnan(val)
+        assert torch.equal(nan_mask, not_injected), (
+            f"NaN mask for '{key}' does not match label==0 mask"
+        )
+
+
+def test_val_params_shape(disk_loader_dataset):
+    from train.data.base import _SignalDataset
+
+    val_waveforms = disk_loader_dataset.val_waveforms
+    val_params = disk_loader_dataset.val_params
+
+    sig_dset = _SignalDataset(val_waveforms, val_params)
+    loader = torch.utils.data.DataLoader(sig_dset, batch_size=4, shuffle=False)
+    batch_wf, batch_params = next(iter(loader))
+
+    assert batch_wf.shape[0] == 4
+    for key, val in batch_params.items():
+        assert val.shape[0] == batch_wf.shape[0], (
+            f"params['{key}'] batch dim {val.shape[0]} != waveform batch dim"
+        )

--- a/projects/train/tests/data/test_e2e_generator.py
+++ b/projects/train/tests/data/test_e2e_generator.py
@@ -1,0 +1,104 @@
+"""
+End-to-end integration test — on-the-fly generator path.
+
+Wires TimeDomainSupervisedAframeDataset + a minimal concrete WaveformGenerator
+and calls inject() with synthetic background and full-length waveforms
+(slice_waveforms is called inside inject() in generator mode).
+"""
+
+import pytest
+import torch
+
+from train.data.supervised.time_domain import TimeDomainSupervisedAframeDataset
+from train.data.waveforms.generator.generator import WaveformGenerator
+
+from conftest import (
+    BATCH_SIZE,
+    IFOS,
+    SAMPLE_RATE,
+    WAVEFORM_SAMPLES,
+    base_dataset_kwargs,
+    make_synthetic_X,
+    make_synthetic_waveforms,
+    setup_dataset_manually,
+)
+
+EXTRINSIC_KEYS = {"dec", "psi", "phi", "snr"}
+
+
+class _TrivialGenerator(WaveformGenerator):
+    """Concrete WaveformGenerator whose forward() returns zeros."""
+
+    def forward(self, **params):
+        n = len(next(iter(params.values())))
+        return torch.zeros(n, 2, WAVEFORM_SAMPLES)
+
+
+@pytest.fixture()
+def generator_dataset(data_dir, val_waveform_file):
+    mock_prior = lambda n, device=None: {  # noqa: E731
+        "mass_1": torch.ones(n),
+        "mass_2": torch.ones(n),
+    }
+    sampler = _TrivialGenerator(
+        ifos=IFOS,
+        sample_rate=SAMPLE_RATE,
+        val_waveform_file=val_waveform_file,
+        training_prior=mock_prior,
+    )
+    dataset = TimeDomainSupervisedAframeDataset(
+        **base_dataset_kwargs(data_dir, sampler)
+    )
+    setup_dataset_manually(dataset)
+    return dataset
+
+
+@pytest.fixture()
+def inject_outputs(generator_dataset):
+    X = make_synthetic_X()
+    waveforms = make_synthetic_waveforms(n=32, sliced=False)
+    params = {"mass_1": torch.arange(32, dtype=torch.float32)}
+    return generator_dataset.inject(X=X, waveforms=waveforms, params=params)
+
+
+def test_param_keys_and_shape(inject_outputs):
+    _, _, params_out = inject_outputs
+    for key in EXTRINSIC_KEYS:
+        assert key in params_out, f"Missing expected key '{key}'"
+    for key, val in params_out.items():
+        assert val.shape == (BATCH_SIZE,), (
+            f"params_out['{key}'] has shape {val.shape},"
+            f" expected ({BATCH_SIZE},)"
+        )
+
+
+def test_nan_matches_labels(inject_outputs):
+    _, y, params_out = inject_outputs
+    not_injected = y.squeeze() == 0
+    for key, val in params_out.items():
+        nan_mask = torch.isnan(val)
+        assert torch.equal(nan_mask, not_injected), (
+            f"NaN mask for '{key}' does not match label==0 mask"
+        )
+
+
+def test_no_state_between_calls(generator_dataset):
+    X = make_synthetic_X()
+    waveforms = make_synthetic_waveforms(n=32, sliced=False)
+    params = {"mass_1": torch.ones(32)}
+
+    results = []
+    for _ in range(2):
+        out = generator_dataset.inject(
+            X=X.clone(), waveforms=waveforms.clone(), params=params
+        )
+        results.append(out)
+
+    for call_idx, (_, _, params_out) in enumerate(results):
+        for key in EXTRINSIC_KEYS:
+            assert key in params_out, f"Call {call_idx}: missing key '{key}'"
+        for key, val in params_out.items():
+            assert val.shape == (BATCH_SIZE,), (
+                f"Call {call_idx}: params_out['{key}'] shape"
+                f" changed to {val.shape}"
+            )

--- a/projects/train/tests/data/test_hdf5_waveform_loader.py
+++ b/projects/train/tests/data/test_hdf5_waveform_loader.py
@@ -1,0 +1,150 @@
+"""
+Unit tests for Hdf5WaveformLoader.
+
+Uses tmp_path + h5py to build minimal HDF5 fixtures with a 'parameters' group.
+"""
+
+import h5py
+import numpy as np
+import pytest
+import torch
+
+from train.data.waveforms.loader import Hdf5WaveformLoader
+
+
+def _write_waveform_hdf5(
+    path, n: int, T: int, param_values: dict | None = None
+):
+    """
+    Write a minimal waveform HDF5 understood by Hdf5WaveformLoader.
+
+    Layout:
+        waveforms/cross  (n, T)
+        waveforms/plus   (n, T)
+        parameters/{key} (n,)  for each key in param_values
+    """
+    rng = np.random.default_rng(42)
+    with h5py.File(path, "w") as f:
+        wf_grp = f.create_group("waveforms")
+        for ch in ("cross", "plus"):
+            wf_grp.create_dataset(
+                ch, data=rng.standard_normal((n, T)).astype(np.float32)
+            )
+        pm_grp = f.create_group("parameters")
+        if param_values:
+            for k, v in param_values.items():
+                pm_grp.create_dataset(k, data=np.asarray(v, dtype=np.float32))
+        else:
+            pm_grp.create_dataset("mass_1", data=np.ones(n, dtype=np.float32))
+
+
+def _make_loader(fnames, batch_size=8, batches_per_epoch=4, chunk_size=4):
+    return Hdf5WaveformLoader(
+        fnames=fnames,
+        channels=["cross", "plus"],
+        batch_size=batch_size,
+        batches_per_epoch=batches_per_epoch,
+        chunk_size=chunk_size,
+        path="waveforms",
+    )
+
+
+class TestLoadChunk:
+    @pytest.fixture()
+    def loader_and_fname(self, tmp_path):
+        n, T = 50, 256
+        path = tmp_path / "waveforms.hdf5"
+        _write_waveform_hdf5(
+            path,
+            n=n,
+            T=T,
+            param_values={"mass_1": np.arange(n, dtype=np.float32)},
+        )
+        loader = _make_loader([path], batch_size=8, chunk_size=8)
+        return loader, path
+
+    def test_waveforms_and_params_same_length(self, loader_and_fname):
+        loader, fname = loader_and_fname
+        wf, params = loader.load_chunk(fname, start=0, size=8)
+        n_wf = next(iter(wf.values())).shape[0]
+        for k, v in params.items():
+            assert v.shape[0] == n_wf, (
+                f"params['{k}'].shape[0]={v.shape[0]} != wf length {n_wf}"
+            )
+
+    def test_end_of_file_clip(self, loader_and_fname):
+        loader, fname = loader_and_fname
+        total = loader.sizes[fname]
+        wf, params = loader.load_chunk(fname, start=total - 3, size=10)
+        expected = 3
+        n_wf = next(iter(wf.values())).shape[0]
+        assert n_wf == expected, (
+            f"Expected {expected} rows after clip, got {n_wf}"
+        )
+        for v in params.values():
+            assert v.shape[0] == expected
+
+
+class TestSampleBatch:
+    @pytest.fixture()
+    def loader(self, tmp_path):
+        n, T = 200, 128
+        path = tmp_path / "waveforms.hdf5"
+        _write_waveform_hdf5(path, n=n, T=T)
+        # batch_size > chunk_size forces multiple chunks per batch
+        return _make_loader([path], batch_size=16, chunk_size=4)
+
+    def test_param_batch_shape(self, loader):
+        _, params = loader.sample_batch()
+        for k, v in params.items():
+            assert v.shape == (16,), f"params['{k}'] shape {v.shape} != (16,)"
+
+    def test_waveform_batch_shape(self, loader):
+        waveforms, _ = loader.sample_batch()
+        assert waveforms.shape == (16, 2, 128)
+
+    def test_param_dtype_matches_hdf5(self, tmp_path):
+        n, T = 100, 64
+        path = tmp_path / "typed.hdf5"
+        _write_waveform_hdf5(
+            path,
+            n=n,
+            T=T,
+            param_values={"mass_1": np.ones(n, dtype=np.float32)},
+        )
+        loader = _make_loader([path], batch_size=8, chunk_size=4)
+        _, params = loader.sample_batch()
+        assert params["mass_1"].dtype == torch.float32
+
+
+def test_multifile_covers_both_files(tmp_path):
+    """
+    Two files with clearly different param values.  Over many batches,
+    observed param values should come from both files.
+    """
+    n, T = 100, 64
+    path_a = tmp_path / "a.hdf5"
+    path_b = tmp_path / "b.hdf5"
+    _write_waveform_hdf5(
+        path_a, n=n, T=T, param_values={"mass_1": np.ones(n, dtype=np.float32)}
+    )
+    _write_waveform_hdf5(
+        path_b,
+        n=n,
+        T=T,
+        param_values={"mass_1": 2 * np.ones(n, dtype=np.float32)},
+    )
+
+    loader = _make_loader(
+        [path_a, path_b], batch_size=8, batches_per_epoch=40, chunk_size=4
+    )
+
+    observed = set()
+    for _, params in loader:
+        observed.update(params["mass_1"].round().int().tolist())
+        if observed == {1, 2}:
+            break
+
+    assert 1 in observed and 2 in observed, (
+        f"Expected params from both files; got values: {observed}"
+    )

--- a/projects/train/tests/data/test_supervised_inject.py
+++ b/projects/train/tests/data/test_supervised_inject.py
@@ -1,0 +1,198 @@
+"""
+Unit tests for SupervisedAframeDataset.inject.
+
+Each test instantiates a TimeDomainSupervisedAframeDataset (which calls
+super().inject via SupervisedAframeDataset) with fixtures from conftest,
+calls build_transforms() to wire up the real PSD estimator / whitener /
+projector, then calls inject() directly.
+"""
+
+import torch
+
+from train.data.supervised.time_domain import TimeDomainSupervisedAframeDataset
+from train.data.waveforms.loader import WaveformLoader
+
+from conftest import (
+    BATCH_SIZE,
+    IFOS,
+    SAMPLE_RATE,
+    base_dataset_kwargs,
+    make_synthetic_X,
+    make_synthetic_waveforms,
+    setup_dataset_manually,
+)
+
+
+def _make_dataset(
+    data_dir,
+    val_waveform_file,
+    training_waveform_file,
+    waveform_prob=1.0,
+    swap_prob=None,
+    mute_prob=None,
+):
+    sampler = WaveformLoader(
+        ifos=IFOS,
+        sample_rate=SAMPLE_RATE,
+        val_waveform_file=val_waveform_file,
+        training_waveform_path=training_waveform_file,
+    )
+    kwargs = base_dataset_kwargs(data_dir, sampler)
+    kwargs["waveform_prob"] = waveform_prob
+    kwargs["swap_prob"] = swap_prob
+    kwargs["mute_prob"] = mute_prob
+    dataset = TimeDomainSupervisedAframeDataset(**kwargs)
+    setup_dataset_manually(dataset)
+    return dataset
+
+
+class TestNanPlacement:
+    def test_all_injected_no_nan(
+        self, data_dir, val_waveform_file, training_waveform_file
+    ):
+        """waveform_prob=1 and no augmentations → no NaN in params."""
+        ds = _make_dataset(
+            data_dir,
+            val_waveform_file,
+            training_waveform_file,
+            waveform_prob=1.0,
+            swap_prob=None,
+            mute_prob=None,
+        )
+        X = make_synthetic_X()
+        waveforms = make_synthetic_waveforms(n=32, sliced=True)
+        params = {"mass_1": torch.ones(32)}
+
+        _, y, params_out = ds.inject(X=X, waveforms=waveforms, params=params)
+        for key, val in params_out.items():
+            assert not torch.isnan(val).any(), (
+                f"Unexpected NaN in '{key}' when all samples"
+                " should be injected"
+            )
+
+    def test_fully_swapped_all_nan(
+        self, data_dir, val_waveform_file, training_waveform_file
+    ):
+        """
+        waveform_prob=1, swap_prob=1 → all injected samples are swapped →
+        mask is reset to all-False → all params must be NaN.
+        """
+        ds = _make_dataset(
+            data_dir,
+            val_waveform_file,
+            training_waveform_file,
+            waveform_prob=1.0,
+            swap_prob=1.0,
+            mute_prob=None,
+        )
+        X = make_synthetic_X()
+        waveforms = make_synthetic_waveforms(n=32, sliced=True)
+        params = {"mass_1": torch.ones(32)}
+
+        _, y, params_out = ds.inject(X=X, waveforms=waveforms, params=params)
+        assert y.sum() == 0, "Expected all labels 0 after swap_prob=1"
+        for key, val in params_out.items():
+            assert torch.isnan(val).all(), (
+                f"Expected all NaN in '{key}' after swap_prob=1"
+            )
+
+    def test_nan_matches_label_zero(
+        self, data_dir, val_waveform_file, training_waveform_file
+    ):
+        """NaN mask equals label==0 for an arbitrary waveform_prob."""
+        ds = _make_dataset(
+            data_dir,
+            val_waveform_file,
+            training_waveform_file,
+            waveform_prob=1.0,
+            swap_prob=0.25,
+            mute_prob=None,
+        )
+        X = make_synthetic_X()
+        waveforms = make_synthetic_waveforms(n=32, sliced=True)
+        params = {"mass_1": torch.ones(32)}
+
+        _, y, params_out = ds.inject(X=X, waveforms=waveforms, params=params)
+        not_injected = y.squeeze() == 0
+        for key, val in params_out.items():
+            assert torch.equal(torch.isnan(val), not_injected), (
+                f"NaN mask for '{key}' does not match label==0"
+            )
+
+
+def test_extrinsic_keys_always_present(
+    data_dir, val_waveform_file, training_waveform_file
+):
+    """Even with an empty input params dict the four extrinsic keys appear."""
+    ds = _make_dataset(
+        data_dir, val_waveform_file, training_waveform_file, waveform_prob=1.0
+    )
+    X = make_synthetic_X()
+    waveforms = make_synthetic_waveforms(n=32, sliced=True)
+
+    _, _, params_out = ds.inject(X=X, waveforms=waveforms, params={})
+
+    for key in ("dec", "psi", "phi", "snr"):
+        assert key in params_out, (
+            f"Expected extrinsic key '{key}' in params_out"
+        )
+        assert params_out[key].shape == (BATCH_SIZE,)
+
+
+def test_param_slicing_consistent_with_waveforms(
+    data_dir, val_waveform_file, training_waveform_file
+):
+    """
+    Encode the waveform index in a scalar param (params['wf_idx'][i] = i).
+    After inject(), injected positions must contain values drawn from
+    {0 … N-1} with no repeats, confirming that params and waveforms
+    were indexed by the same randperm.
+    """
+    ds = _make_dataset(
+        data_dir,
+        val_waveform_file,
+        training_waveform_file,
+        waveform_prob=1.0,
+        swap_prob=None,
+        mute_prob=None,
+    )
+    N = 32
+    X = make_synthetic_X()
+    waveforms = make_synthetic_waveforms(n=N, sliced=True)
+    params = {"wf_idx": torch.arange(N, dtype=torch.float32)}
+
+    _, y, params_out = ds.inject(X=X, waveforms=waveforms, params=params)
+
+    injected_mask = y.squeeze() == 1
+    selected_vals = params_out["wf_idx"][injected_mask]
+
+    assert (selected_vals >= 0).all() and (selected_vals < N).all()
+    assert selected_vals.numel() == selected_vals.unique().numel()
+
+
+def test_swap_makes_params_nan(
+    data_dir, val_waveform_file, training_waveform_file
+):
+    """
+    With swap_prob=1.0 every injected waveform gets swapped, so the
+    final mask is all-False and every param entry must be NaN.
+    """
+    ds = _make_dataset(
+        data_dir,
+        val_waveform_file,
+        training_waveform_file,
+        waveform_prob=1.0,
+        swap_prob=1.0,
+        mute_prob=None,
+    )
+    X = make_synthetic_X()
+    waveforms = make_synthetic_waveforms(n=32, sliced=True)
+    params = {"mass_1": torch.ones(32)}
+
+    _, y, params_out = ds.inject(X=X, waveforms=waveforms, params=params)
+
+    assert y.sum() == 0, "Expected all labels to be 0 after full swap"
+    for key, val in params_out.items():
+        assert torch.isnan(val).all(), (
+            f"Expected all NaN in '{key}' after swap_prob=1.0"
+        )

--- a/projects/train/tests/data/test_waveform_generator.py
+++ b/projects/train/tests/data/test_waveform_generator.py
@@ -1,0 +1,70 @@
+"""
+Unit tests for WaveformGenerator.sample.
+"""
+
+import torch
+
+from train.data.waveforms.generator.generator import WaveformGenerator
+
+from conftest import (
+    IFOS,
+    SAMPLE_RATE,
+    WAVEFORM_SAMPLES,
+    make_val_waveform_file,
+)
+
+import pytest
+
+N = 12
+T = WAVEFORM_SAMPLES
+NUM_CHANNELS = 2  # cross + plus
+
+
+class _ConcreteGenerator(WaveformGenerator):
+    """Minimal WaveformGenerator with a working forward()."""
+
+    def forward(self, **params):
+        n = len(next(iter(params.values())))
+        return torch.zeros(n, NUM_CHANNELS, T)
+
+
+@pytest.fixture()
+def generator(tmp_path):
+    val_file = make_val_waveform_file(tmp_path)
+    prior_params = {
+        "mass_1": torch.ones(N),
+        "mass_2": torch.ones(N),
+    }
+
+    def mock_prior(n, device=None):
+        return {k: v[:n] for k, v in prior_params.items()}
+
+    return _ConcreteGenerator(
+        ifos=IFOS,
+        sample_rate=SAMPLE_RATE,
+        val_waveform_file=val_file,
+        training_prior=mock_prior,
+    )
+
+
+def test_sample_returns_correct_shapes(generator):
+    X = torch.zeros(N, len(IFOS), 100)  # dummy background, only len() is used
+    waveforms, parameters = generator.sample(X)
+
+    assert waveforms.shape == (N, NUM_CHANNELS, T), (
+        f"Waveform shape {waveforms.shape} != ({N}, {NUM_CHANNELS}, {T})"
+    )
+    assert isinstance(parameters, dict), "parameters should be a dict"
+    for key, val in parameters.items():
+        assert len(val) == N, (
+            f"parameters['{key}'] has length {len(val)}, expected {N}"
+        )
+
+
+def test_sample_returns_prior_parameters(generator):
+    """sample() must return the exact dict produced by training_prior."""
+    X = torch.zeros(N, len(IFOS), 100)
+    _, parameters = generator.sample(X)
+    assert "mass_1" in parameters
+    assert "mass_2" in parameters
+    assert torch.equal(parameters["mass_1"], torch.ones(N))

--- a/projects/train/tests/data/test_waveform_sampler.py
+++ b/projects/train/tests/data/test_waveform_sampler.py
@@ -1,0 +1,123 @@
+"""
+Unit tests for WaveformSampler.get_val_waveforms.
+
+Uses minimal mock WaveformSet-like objects and real HDF5 fixtures to
+avoid touching the filesystem beyond what's needed.
+"""
+
+import math
+from dataclasses import fields
+
+from ledger.injections import WaveformSet, waveform_class_factory
+
+from train.data.waveforms.sampler import WaveformSampler
+
+from conftest import (
+    IFOS,
+    SAMPLE_RATE,
+    make_val_waveform_file,
+)
+
+
+def _make_sampler(val_waveform_file):
+    """Instantiate a minimal concrete WaveformSampler subclass."""
+
+    class _Sampler(WaveformSampler):
+        def sample(self, X):
+            raise NotImplementedError
+
+        def get_test_waveforms(self):
+            raise NotImplementedError
+
+    return _Sampler(
+        ifos=IFOS,
+        sample_rate=SAMPLE_RATE,
+        val_waveform_file=val_waveform_file,
+    )
+
+
+def test_only_parameter_fields_returned(tmp_path):
+    """
+    The val waveform file contains parameter, waveform, and metadata fields.
+    Only fields with kind='parameter' should appear in the returned params
+    dict.
+    """
+    val_file = make_val_waveform_file(tmp_path)
+    sampler = _make_sampler(val_file)
+
+    WS = waveform_class_factory(IFOS, WaveformSet, "WaveformSet")
+    _, params = sampler.get_val_waveforms(world_size=1, rank=0)
+
+    parameter_names = {
+        f.name for f in fields(WS) if f.metadata.get("kind") == "parameter"
+    }
+    waveform_names = {
+        f.name for f in fields(WS) if f.metadata.get("kind") == "waveform"
+    }
+
+    for key in params:
+        assert key in parameter_names, (
+            f"Returned key '{key}' is not a 'parameter' field"
+        )
+
+    assert not waveform_names.intersection(params.keys()), (
+        "Waveform-kind fields leaked into params dict"
+    )
+
+
+def test_non_ndarray_params_skipped(tmp_path):
+    """
+    If a parameter field holds a scalar instead of an ndarray,
+    get_val_waveforms should skip it silently (no KeyError / TypeError).
+    """
+    from unittest.mock import MagicMock, PropertyMock, patch
+
+    val_file = make_val_waveform_file(tmp_path)
+    sampler = _make_sampler(val_file)
+
+    WS = waveform_class_factory(IFOS, WaveformSet, "WaveformSet")
+    real_ws = WS.read(val_file)
+
+    target_field = next(
+        f.name
+        for f in fields(real_ws)
+        if f.metadata.get("kind") == "parameter"
+    )
+    setattr(real_ws, target_field, 42.0)
+
+    mock_cls = MagicMock()
+    mock_cls.read.return_value = real_ws
+
+    with patch.object(
+        type(sampler),
+        "waveform_set_cls",
+        new_callable=PropertyMock,
+        return_value=mock_cls,
+    ):
+        _, params = sampler.get_val_waveforms(world_size=1, rank=0)
+
+    assert target_field not in params, (
+        f"Scalar field '{target_field}' should have been skipped"
+    )
+
+
+def test_world_size_slicing_consistent(tmp_path):
+    """
+    With world_size=2, rank=0: waveforms and every param tensor should
+    have the same length (half of total, rounded up).
+    """
+    n_total = 20
+    val_file = make_val_waveform_file(tmp_path, n=n_total)
+    sampler = _make_sampler(val_file)
+
+    waveforms, params = sampler.get_val_waveforms(world_size=2, rank=0)
+
+    expected_len = math.ceil(n_total / 2)
+    assert len(waveforms) == expected_len, (
+        f"Expected {expected_len} waveforms for rank 0, got {len(waveforms)}"
+    )
+    for key, val in params.items():
+        assert len(val) == len(waveforms), (
+            f"params['{key}'] length {len(val)} != "
+            f"waveforms length {len(waveforms)}"
+        )

--- a/projects/train/train/callbacks.py
+++ b/projects/train/train/callbacks.py
@@ -1,7 +1,8 @@
 import io
 import os
 import shutil
-from typing import Optional
+from typing import Optional, Union, Literal
+from pathlib import Path
 
 import h5py
 import s3fs
@@ -13,6 +14,58 @@ from lightning.pytorch.loggers import WandbLogger
 from lightning.pytorch.utilities import grad_norm
 
 BOTO_RETRY_EXCEPTIONS = (ClientError, ConnectTimeoutError)
+
+
+class AframeWandbLogger(WandbLogger):
+    """Thin wrapper around WandbLogger with clean type annotations.
+
+    WandbLogger.__init__ uses ForwardRef('Run') / ForwardRef('RunDisabled')
+    for the `experiment` parameter, which breaks jsonargparse's get_type_hints
+    call. This subclass re-declares __init__ without that parameter so the
+    Lightning CLI can instantiate it from a YAML config.
+    """
+
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        save_dir: Union[str, Path] = ".",
+        version: Optional[str] = None,
+        offline: bool = False,
+        dir: Optional[Union[str, Path]] = None,
+        id: Optional[str] = None,
+        anonymous: Optional[bool] = None,
+        project: Optional[str] = None,
+        log_model: Union[Literal["all"], bool] = False,
+        prefix: str = "",
+        checkpoint_name: Optional[str] = None,
+    ):
+        super().__init__(
+            name=name,
+            save_dir=save_dir,
+            version=version,
+            offline=offline,
+            dir=dir,
+            id=id,
+            anonymous=anonymous,
+            project=project,
+            log_model=log_model,
+            prefix=prefix,
+            checkpoint_name=checkpoint_name,
+            save_code=True,
+        )
+
+        self._offline = offline
+
+    @property
+    def experiment(self):
+        # Accessing the parent's experiment property initializes the run
+        exp = super().experiment
+        # The run has a log_code method
+        if not getattr(self, "_code_logged", False):
+            if not getattr(self, "offline", False):
+                exp.log_code("train")
+            self._code_logged = True
+        return exp
 
 
 class WandbSaveConfig(pl.cli.SaveConfigCallback):

--- a/projects/train/train/callbacks.py
+++ b/projects/train/train/callbacks.py
@@ -53,7 +53,6 @@ class ModelCheckpoint(pl.callbacks.ModelCheckpoint):
             [X] = next(iter(trainer.train_dataloader))
             X = X.to(device)
             waveforms, params = trainer.datamodule.waveform_sampler.sample(X)
-            waveforms = trainer.datamodule.slice_waveforms(waveforms)
         X, y, _ = trainer.datamodule.inject(X, waveforms, params)
         if isinstance(X, tuple):
             X = tuple(i.cpu() for i in X)
@@ -96,7 +95,6 @@ class SaveAugmentedBatch(Callback):
                 waveforms, params = trainer.datamodule.waveform_sampler.sample(
                     X
                 )
-                waveforms = trainer.datamodule.slice_waveforms(waveforms)
             X, y, _ = trainer.datamodule.inject(X, waveforms, params)
             # If X is not a tuple, make it one for consistency
             # of format for saving to file below

--- a/projects/train/train/callbacks.py
+++ b/projects/train/train/callbacks.py
@@ -45,14 +45,16 @@ class ModelCheckpoint(pl.callbacks.ModelCheckpoint):
         device = pl_module.device
         # Handle the case of loading training waveforms from disk
         if trainer.datamodule.waveforms_from_disk:
-            [X], waveforms = next(iter(trainer.train_dataloader))
+            [X], (waveforms, params) = next(iter(trainer.train_dataloader))
             X = X.to(device)
             waveforms = waveforms.to(device)
-            X, y = trainer.datamodule.inject(X, waveforms)
+            params = {k: v.to(device) for k, v in params.items()}
         else:
             [X] = next(iter(trainer.train_dataloader))
             X = X.to(device)
-            X, y = trainer.datamodule.inject(X)
+            waveforms, params = trainer.datamodule.waveform_sampler.sample(X)
+            waveforms = trainer.datamodule.slice_waveforms(waveforms)
+        X, y, _ = trainer.datamodule.inject(X, waveforms, params)
         if isinstance(X, tuple):
             X = tuple(i.cpu() for i in X)
         else:
@@ -84,27 +86,32 @@ class SaveAugmentedBatch(Callback):
             # build training batch by hand
             # Handle the case of loading training waveforms from disk
             if trainer.datamodule.waveforms_from_disk:
-                [X], waveforms = next(iter(trainer.train_dataloader))
+                [X], (waveforms, params) = next(iter(trainer.train_dataloader))
                 X = X.to(device)
                 waveforms = waveforms.to(device)
-                X, y = trainer.datamodule.inject(X, waveforms)
+                params = {k: v.to(device) for k, v in params.items()}
             else:
                 [X] = next(iter(trainer.train_dataloader))
                 X = X.to(device)
-                X, y = trainer.datamodule.inject(X)
+                waveforms, params = trainer.datamodule.waveform_sampler.sample(
+                    X
+                )
+                waveforms = trainer.datamodule.slice_waveforms(waveforms)
+            X, y, _ = trainer.datamodule.inject(X, waveforms, params)
             # If X is not a tuple, make it one for consistency
             # of format for saving to file below
             if not isinstance(X, tuple):
                 X = (X,)
 
             # build val batch by hand
-            [background, _, _], [signals] = next(
+            [background, _, _], [signals, params] = next(
                 iter(trainer.datamodule.val_dataloader())
             )
             background = background.to(device)
             signals = signals.to(device)
-            X_bg, X_inj = trainer.datamodule.build_val_batches(
-                background, signals
+            params = {k: v.to(device) for k, v in params.items()}
+            X_bg, X_inj, _ = trainer.datamodule.build_val_batches(
+                background, signals, params
             )
             # Make background and injected validation data into
             # tuples for consistency if necessary

--- a/projects/train/train/data/base.py
+++ b/projects/train/train/data/base.py
@@ -32,6 +32,17 @@ TransformedDist = torch.distributions.TransformedDistribution
 SECONDS_PER_DAY = 86400
 
 
+class _SignalDataset(torch.utils.data.Dataset):
+    def __init__(self, waveforms, params):
+        self.waveforms, self.params = waveforms, params
+
+    def __len__(self):
+        return len(self.waveforms)
+
+    def __getitem__(self, i):
+        return self.waveforms[i], {k: v[i] for k, v in self.params.items()}
+
+
 # TODO: using this right now because
 # lightning.pytorch.utilities.CombinedLoader
 # is not supported when calling `.fit`. Once
@@ -246,14 +257,13 @@ class BaseAframeDataset(pl.LightningDataModule):
         fs_utils.download_training_data(bucket, self.background_dir)
 
         bucket, _ = fs_utils.split_data_dir(self.hparams.waveforms_dir)
-        if bucket is None:
-            return
-        logger.info(
-            "Downloading waveform data from S3 bucket {} to {}".format(
-                bucket, self.waveforms_dir
+        if bucket is not None:
+            logger.info(
+                "Downloading waveform data from S3 bucket {} to {}".format(
+                    bucket, self.waveforms_dir
+                )
             )
-        )
-        fs_utils.download_training_data(bucket, self.waveforms_dir)
+            fs_utils.download_training_data(bucket, self.waveforms_dir)
 
     # ================================================ #
     # Distribution utilities
@@ -374,9 +384,11 @@ class BaseAframeDataset(pl.LightningDataModule):
     @property
     def num_workers(self):
         local_world_size = len(self.trainer.device_ids)
-        return min(
+        num_workers = min(
             self.max_num_workers, int(os.cpu_count() / local_world_size)
         )
+        self._logger.info(f"Using {num_workers} workers for data loading")
+        return num_workers
 
     # ================================================== #
     # Utilities for initial data loading and preparation #
@@ -513,8 +525,8 @@ class BaseAframeDataset(pl.LightningDataModule):
             self.val_batch_size,
         )
 
-        self.val_waveforms = self.waveform_sampler.get_val_waveforms(
-            world_size, rank
+        self.val_waveforms, self.val_params = (
+            self.waveform_sampler.get_val_waveforms(world_size, rank)
         )
         if self.waveforms_from_disk:
             self.waveform_sampler.get_train_waveforms(
@@ -537,9 +549,9 @@ class BaseAframeDataset(pl.LightningDataModule):
         # waveform loader to reduce quantity of data
         # we need to load
         if self.trainer.training and self.waveforms_from_disk:
-            X, waveforms = batch
+            X, [waveforms, params] = batch
             waveforms = self.slice_waveforms(waveforms)
-            batch = X, waveforms
+            batch = X, (waveforms, params)
         return batch
 
     # ============================================== #
@@ -558,17 +570,19 @@ class BaseAframeDataset(pl.LightningDataModule):
             # if we're training, perform random augmentations
             # on input data and use it to impact labels
             if self.waveforms_from_disk:
-                [batch], waveforms = batch
-                batch = self.inject(batch, waveforms)
+                [X], (waveforms, params) = batch
+                batch = self.inject(X=X, waveforms=waveforms, params=params)
             else:
-                [batch] = batch
-                batch = self.inject(batch)
+                [X] = batch
+                waveforms, params = self.waveform_sampler.sample(X)
+                waveforms = self.slice_waveforms(waveforms)
+                batch = self.inject(X=X, waveforms=waveforms, params=params)
         elif self.trainer.validating or self.trainer.sanity_checking:
             # If we're in validation mode but we're not validating
             # on the local device, the relevant tensors will be
             # empty, so just pass them through with a 0 shift to
             # indicate that this should be ignored
-            [background, _, timeslide_idx], [signals] = batch
+            [background, _, timeslide_idx], [signals, params] = batch
 
             # If we're validating, unfold the background
             # data into a batch of overlapping kernels now that
@@ -576,12 +590,16 @@ class BaseAframeDataset(pl.LightningDataModule):
             # much data from CPU to GPU. Once everything is
             # on-device, pre-inject signals into background.
             shift = self.timeslides[timeslide_idx].shift_size
-            X_bg, X_fg = self.build_val_batches(background, signals)
-            batch = (shift, X_bg, X_fg)
+            X_bg, X_fg, params = self.build_val_batches(
+                background=background,
+                signals=signals,
+                params=params,
+            )
+            batch = (shift, X_bg, X_fg, params)
         return batch
 
     @torch.no_grad()
-    def inject(self, X):
+    def inject(self, X: Tensor, waveforms: Tensor, params: dict[str, Tensor]):
         """
         Override this in child classes to define
         application-specific augmentations
@@ -596,7 +614,8 @@ class BaseAframeDataset(pl.LightningDataModule):
         self,
         background: Tensor,
         signals: Tensor,
-    ) -> tuple[Tensor, Tensor, Tensor]:
+        params: dict[str, Tensor],
+    ) -> tuple[Tensor, Tensor, Tensor, dict[str, Tensor]]:
         """
         Unfold a timeseries of background data
         into a batch of kernels, then inject
@@ -606,9 +625,11 @@ class BaseAframeDataset(pl.LightningDataModule):
         Args:
             background: A tensor of background data
             signals: A tensor of signals to inject
+            params: A dictionary of parameter tensors to be passed to the model
 
         Returns:
-            raw strain background kernels, injected kernels, and psds
+            raw strain background kernels, injected kernels, psds,
+            and (potentially truncated) params tensor
         """
 
         # unfold the background data into kernels
@@ -625,6 +646,7 @@ class BaseAframeDataset(pl.LightningDataModule):
         step = int(len(X) / len(signals))
         if not step:
             signals = signals[: len(X)]
+            params = {k: v[: len(X)] for k, v in params.items()}
         else:
             X = X[::step][: len(signals)]
             psd = psd[::step][: len(signals)]
@@ -658,7 +680,7 @@ class BaseAframeDataset(pl.LightningDataModule):
             X_inj.append(injected)
         X_inj = torch.stack(X_inj)
 
-        return X, X_inj, psd
+        return X, X_inj, psd, params
 
     def val_dataloader(self) -> ZippedDataset:
         """
@@ -676,7 +698,9 @@ class BaseAframeDataset(pl.LightningDataModule):
         # throughout all those batches.
         num_waveforms = len(self.val_waveforms)
         signal_batch_size = (num_waveforms - 1) // self.valid_loader_length + 1
-        signal_dataset = torch.utils.data.TensorDataset(self.val_waveforms)
+
+        # Signal dataset to return tuples of (waveform, params)
+        signal_dataset = _SignalDataset(self.val_waveforms, self.val_params)
         signal_loader = torch.utils.data.DataLoader(
             signal_dataset,
             batch_size=signal_batch_size,

--- a/projects/train/train/data/base.py
+++ b/projects/train/train/data/base.py
@@ -575,7 +575,6 @@ class BaseAframeDataset(pl.LightningDataModule):
             else:
                 [X] = batch
                 waveforms, params = self.waveform_sampler.sample(X)
-                waveforms = self.slice_waveforms(waveforms)
                 batch = self.inject(X=X, waveforms=waveforms, params=params)
         elif self.trainer.validating or self.trainer.sanity_checking:
             # If we're in validation mode but we're not validating

--- a/projects/train/train/data/base.py
+++ b/projects/train/train/data/base.py
@@ -197,6 +197,7 @@ class BaseAframeDataset(pl.LightningDataModule):
         chunks_per_epoch: int = 1,
         chunk_size: int = 10000,
         verbose: bool = False,
+        param_transforms: Optional[list[Callable]] = None,
     ) -> None:
         super().__init__()
         self.init_logging(verbose)
@@ -218,6 +219,7 @@ class BaseAframeDataset(pl.LightningDataModule):
         self._on_device = False
 
         self.dec, self.psi, self.phi = dec, psi, phi
+        self.param_transforms = param_transforms or []
         self.waveform_sampler = waveform_sampler
         # If we're using a `WaveformLoader`, we're loading
         # training waveforms from disk, so have a flag tp
@@ -595,8 +597,16 @@ class BaseAframeDataset(pl.LightningDataModule):
                 signals=signals,
                 params=params,
             )
+            params = self.apply_param_transforms(params)
             batch = (shift, X_bg, X_fg, params)
         return batch
+
+    def apply_param_transforms(
+        self, params: dict[str, Tensor]
+    ) -> dict[str, Tensor]:
+        for transform in self.param_transforms:
+            params = transform(params)
+        return params
 
     @torch.no_grad()
     def inject(self, X: Tensor, waveforms: Tensor, params: dict[str, Tensor]):

--- a/projects/train/train/data/supervised/multimodal.py
+++ b/projects/train/train/data/supervised/multimodal.py
@@ -4,8 +4,10 @@ from train.data.supervised.supervised import SupervisedAframeDataset
 
 
 class MultiModalSupervisedAframeDataset(SupervisedAframeDataset):
-    def build_val_batches(self, background, signals):
-        X_bg, X_inj, psds = super().build_val_batches(background, signals)
+    def build_val_batches(self, background, signals, params):
+        X_bg, X_inj, psds, params = super().build_val_batches(
+            background=background, signals=signals, params=params
+        )
         X_bg = self.whitener(X_bg, psds)
         X_bg_fft = self.compute_frequency_domain_data(X_bg, psds)
         # whiten each view of injections
@@ -23,7 +25,7 @@ class MultiModalSupervisedAframeDataset(SupervisedAframeDataset):
         asds *= 1e23
         asds = asds.float()
 
-        return (X_bg, X_bg_fft), (X_fg, X_fg_fft)
+        return (X_bg, X_bg_fft), (X_fg, X_fg_fft), params
 
     def compute_frequency_domain_data(self, X, psds):
         asds = psds**0.5
@@ -53,9 +55,11 @@ class MultiModalSupervisedAframeDataset(SupervisedAframeDataset):
 
         return X_fft
 
-    def inject(self, X, waveforms=None):
-        X, y, psds = super().inject(X, waveforms)
+    def inject(self, X, waveforms, params):
+        X, y, psds, params_out = super().inject(
+            X=X, waveforms=waveforms, params=params
+        )
         X = self.whitener(X, psds)
         X_fft = self.compute_frequency_domain_data(X, psds)
 
-        return (X, X_fft), y
+        return (X, X_fft), y, params_out

--- a/projects/train/train/data/supervised/supervised.py
+++ b/projects/train/train/data/supervised/supervised.py
@@ -16,7 +16,7 @@ class SupervisedAframeDataset(BaseAframeDataset):
         **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
-        if swap_prob is not None and 0 < swap_prob < 1:
+        if swap_prob is not None and 0 <= swap_prob <= 1:
             self.swapper = aug.ChannelSwapper(swap_prob)
             self.swap_prob = swap_prob
         elif swap_prob is not None:
@@ -27,7 +27,7 @@ class SupervisedAframeDataset(BaseAframeDataset):
             self.swapper = None
             self.swap_prob = 0
 
-        if mute_prob is not None and 0 < mute_prob < 1:
+        if mute_prob is not None and 0 <= mute_prob <= 1:
             self.muter = aug.ChannelMuter(mute_prob)
             self.mute_prob = mute_prob
         elif mute_prob is not None:
@@ -43,11 +43,14 @@ class SupervisedAframeDataset(BaseAframeDataset):
         return self.hparams.waveform_prob + self.swap_prob + self.mute_prob
 
     @torch.no_grad()
-    def inject(self, X, waveforms=None):
-        if self.waveforms_from_disk and waveforms is None:
+    def inject(
+        self, X, waveforms, params
+    ) -> tuple[
+        torch.Tensor, torch.Tensor, torch.Tensor, dict[str, torch.Tensor]
+    ]:
+        if waveforms is None:
             raise ValueError(
-                "Waveforms should be passed to the `inject` method "
-                "if waveforms are being loaded from disk, got None"
+                "Waveforms should be passed to the `inject` method, got None"
             )
 
         X, psds = self.psd_estimator(X)
@@ -60,25 +63,22 @@ class SupervisedAframeDataset(BaseAframeDataset):
         mask = rvs < self.sample_prob
 
         dec, psi, phi = self.sample_extrinsic(X[mask])
-        # If we're loading waveforms from disk, we can
-        # slice out the ones we want.
-        # If not, we're generating them on the fly.
-        if self.waveforms_from_disk:
-            # TODO: Can we just use `mask` to slice out the
-            # waveforms we want here? Copying this from the
-            # old `WaveformSampler` in case it handles edge
-            # cases I'm not thinking of
-            N = mask.sum().item()
-            idx = torch.randperm(waveforms.shape[0])[:N]
-            waveforms = waveforms[idx].to(X.device).float()
-            hc, hp = waveforms[:, 0], waveforms[:, 1]
-        else:
-            hc, hp = self.waveform_sampler.sample(X[mask])
+        N = mask.sum().item()
+        idx = torch.randperm(waveforms.shape[0])[:N]
+        waveforms = waveforms[idx].to(X.device).float()
+        params = {k: v[idx].to(X.device).float() for k, v in params.items()}
+        hc, hp = waveforms[:, 0], waveforms[:, 1]
 
         snrs = self.snr_sampler.sample((mask.sum().item(),)).to(X.device)
         responses = self.projector(
             dec, psi, phi, snrs, psds[mask], cross=hc, plus=hp
         )
+
+        params["dec"] = dec
+        params["psi"] = psi
+        params["phi"] = phi
+        params["snr"] = snrs
+
         # If we're loading waveforms from disk, we'll have sliced
         # the waveforms already in `on_before_batch_transfer`
         if not self.waveforms_from_disk:
@@ -106,4 +106,12 @@ class SupervisedAframeDataset(BaseAframeDataset):
         y = torch.zeros((X.size(0), 1), device=X.device)
         y[mask] += 1
 
-        return X, y, psds
+        # return NaN for params that weren't injected
+        still_injected = mask[idx]
+        params_out = {}
+        for key, vals in params.items():
+            out = torch.full((X.size(0),), float("nan"), device=X.device)
+            out[idx[still_injected]] = vals[still_injected]
+            params_out[key] = out
+
+        return X, y, psds, params_out

--- a/projects/train/train/data/supervised/supervised.py
+++ b/projects/train/train/data/supervised/supervised.py
@@ -114,4 +114,6 @@ class SupervisedAframeDataset(BaseAframeDataset):
             out[idx[still_injected]] = vals[still_injected]
             params_out[key] = out
 
+        params_out = self.apply_param_transforms(params_out)
+
         return X, y, psds, params_out

--- a/projects/train/train/data/supervised/time_domain.py
+++ b/projects/train/train/data/supervised/time_domain.py
@@ -7,8 +7,10 @@ from ml4gw.transforms import Heterodyne
 
 
 class TimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
-    def build_val_batches(self, background, signals):
-        X_bg, X_inj, psds = super().build_val_batches(background, signals)
+    def build_val_batches(self, background, signals, params):
+        X_bg, X_inj, psds, params_out = super().build_val_batches(
+            background=background, signals=signals, params=params
+        )
         X_bg = self.whitener(X_bg, psds)
         # whiten each view of injections
         X_fg = []
@@ -17,12 +19,14 @@ class TimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
             X_fg.append(inj)
 
         X_fg = torch.stack(X_fg)
-        return X_bg, X_fg
+        return X_bg, X_fg, params_out
 
-    def inject(self, X, waveforms=None):
-        X, y, psds = super().inject(X, waveforms)
+    def inject(self, X, waveforms, params):
+        X, y, psds, params_out = super().inject(
+            X=X, waveforms=waveforms, params=params
+        )
         X = self.whitener(X, psds)
-        return X, y
+        return X, y, params_out
 
 
 class HeterodyneTimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
@@ -104,8 +108,11 @@ class HeterodyneTimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
                 f"Invalid chirp mass spacing: {chirp_mass_spacing}"
             )
 
-    def build_val_batches(self, background, signals):
-        X_bg, X_inj, psds = super().build_val_batches(background, signals)
+    def build_val_batches(self, background, signals, params):
+        X_bg, X_inj, psds, params_out = super().build_val_batches(
+            background=background, signals=signals, params=params
+        )
+
         X_bg = self.whitener(X_bg, psds)
         X_bg = self.heterodyne_transform(X_bg)
         _B_bg, _C_bg, _M_bg, _T_bg = X_bg.shape
@@ -121,20 +128,24 @@ class HeterodyneTimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
         X_fg = X_fg.view(_V_fg, _B_fg, _C_fg * _M_fg, _T_fg)
 
         if self.keep_last_n_seconds is not None:
-            return X_bg[..., -self.keep_last_n_samples :], X_fg[
-                ..., -self.keep_last_n_samples :
-            ]
+            return (
+                X_bg[..., -self.keep_last_n_samples :],
+                X_fg[..., -self.keep_last_n_samples :],
+                params_out,
+            )
         else:
-            return X_bg, X_fg
+            return X_bg, X_fg, params_out
 
-    def inject(self, X, waveforms=None):
-        X, y, psds = super().inject(X, waveforms)
+    def inject(self, X, waveforms, params):
+        X, y, psds, params_out = super().inject(
+            X=X, waveforms=waveforms, params=params
+        )
         X = self.whitener(X, psds)
         X = self.heterodyne_transform(X)
         _B, _C, _M, _T = X.shape
         X = X.view(_B, _C * _M, _T)
 
         if self.keep_last_n_seconds is not None:
-            return X[..., -self.keep_last_n_samples :], y
+            return X[..., -self.keep_last_n_samples :], y, params_out
         else:
-            return X, y
+            return X, y, params_out

--- a/projects/train/train/data/supervised/time_frequency_domain.py
+++ b/projects/train/train/data/supervised/time_frequency_domain.py
@@ -23,16 +23,20 @@ class SpectrogramDomainSupervisedAframeDataset(SupervisedAframeDataset):
             spectrogram_shape=self.spectrogram_shape,
         )
 
-    def inject(self, X, waveforms=None):
-        X, y, psds = super().inject(X, waveforms)
+    def inject(self, X, waveforms, params):
+        X, y, psds, params_out = super().inject(
+            X=X, waveforms=waveforms, params=params
+        )
         X = self.whitener(X, psds)
         X = self.qtransform(X)
-        return X, y
+        return X, y, params_out
 
     def build_val_batches(
-        self, background: Tensor, signals: Tensor
+        self, background: Tensor, signals: Tensor, params: dict[str, Tensor]
     ) -> tuple[Tensor, Tensor]:
-        X_bg, X_inj, psds = super().build_val_batches(background, signals)
+        X_bg, X_inj, psds, params_out = super().build_val_batches(
+            background=background, signals=signals, params=params
+        )
 
         # whiten and q transform background
         X_bg = self.whitener(X_bg, psds)
@@ -45,7 +49,7 @@ class SpectrogramDomainSupervisedAframeDataset(SupervisedAframeDataset):
             X_fg.append(self.qtransform(inj))
 
         X_fg = torch.stack(X_fg)
-        return X_bg, X_fg
+        return X_bg, X_fg, params_out
 
 
 class FrequencyDomainSupervisedAframeDataset(SupervisedAframeDataset):
@@ -106,7 +110,9 @@ class FrequencyDomainSupervisedAframeDataset(SupervisedAframeDataset):
         return X
 
     def build_val_batches(self, *args, **kwargs):
-        X_bg, X_inj, psds = super().build_val_batches(*args, **kwargs)
+        X_bg, X_inj, psds, params_out = super().build_val_batches(
+            *args, **kwargs
+        )
 
         # fft whiten and bandpass in frequency domain
         X_bg = self.whiten(X_bg, psds)
@@ -115,17 +121,19 @@ class FrequencyDomainSupervisedAframeDataset(SupervisedAframeDataset):
         X_bg = torch.cat([X_bg.real, X_bg.imag], dim=-2)
         X_inj = torch.cat([X_inj.real, X_inj.imag], dim=-2)
 
-        return X_bg, X_inj
+        return X_bg, X_inj, params_out
 
-    def inject(self, X, waveforms=None):
-        X, y, psds = super().inject(X, waveforms)
+    def inject(self, X, waveforms, params):
+        X, y, psds, params_out = super().inject(
+            X=X, waveforms=waveforms, params=params
+        )
 
         # fft whiten and bandpass in frequency domain
         X = self.whiten(X, psds)
 
         # split into real and imaginary parts
         X = torch.cat([X.real, X.imag], dim=1)
-        return X, y
+        return X, y, params_out
 
 
 class TimeSpectrogramDomainSupervisedAframeDataset(SupervisedAframeDataset):
@@ -190,8 +198,10 @@ class TimeSpectrogramDomainSupervisedAframeDataset(SupervisedAframeDataset):
             spectrogram_shape=self.spectrogram_shape,
         )
 
-    def build_val_batches(self, background, signals):
-        X_bg, X_inj, psds = super().build_val_batches(background, signals)
+    def build_val_batches(self, background, signals, params):
+        X_bg, X_inj, psds, params_out = super().build_val_batches(
+            background=background, signals=signals, params=params
+        )
 
         # whiten each view of backgrounds and injections
         X_bg = self.whitener(X_bg, psds)
@@ -215,10 +225,12 @@ class TimeSpectrogramDomainSupervisedAframeDataset(SupervisedAframeDataset):
         X_fg_spec = torch.stack(X_fg_spec)
 
         # first input is timeseries and second input is spectrogram
-        return (X_bg[1], X_bg_spec), (X_fg[1], X_fg_spec)
+        return (X_bg[1], X_bg_spec), (X_fg[1], X_fg_spec), params_out
 
-    def inject(self, X, waveforms=None):
-        X, y, psds = super().inject(X, waveforms)
+    def inject(self, X, waveforms, params):
+        X, y, psds, params_out = super().inject(
+            X=X, waveforms=waveforms, params=params
+        )
         X = self.whitener(X, psds)
         if self.decimator is not None:
             X = self.decimator(X)
@@ -227,4 +239,4 @@ class TimeSpectrogramDomainSupervisedAframeDataset(SupervisedAframeDataset):
         X_spec = self.qtransform(X[0])
 
         # first input is timeseries and second input is spectrogram
-        return (X[1], X_spec), y
+        return (X[1], X_spec), y, params_out

--- a/projects/train/train/data/waveforms/generator/cbc.py
+++ b/projects/train/train/data/waveforms/generator/cbc.py
@@ -55,6 +55,4 @@ class CBCGenerator(WaveformGenerator):
 
     def forward(self, **parameters) -> torch.Tensor:
         hc, hp = self.waveform_generator(**parameters)
-        waveforms = torch.stack([hc, hp], dim=1)
-        hc, hp = waveforms.transpose(1, 0)
-        return hc.float(), hp.float()
+        return torch.stack([hc, hp], dim=1).float()

--- a/projects/train/train/data/waveforms/generator/generator.py
+++ b/projects/train/train/data/waveforms/generator/generator.py
@@ -29,8 +29,8 @@ class WaveformGenerator(WaveformSampler):
     def sample(self, X: torch.Tensor):
         N = len(X)
         parameters = self.training_prior(N, device=X.device)
-        hc, hp = self(**parameters)
-        return hc, hp
+        waveforms = self(**parameters)
+        return waveforms, parameters
 
     def forward(self):
         raise NotImplementedError

--- a/projects/train/train/data/waveforms/loader.py
+++ b/projects/train/train/data/waveforms/loader.py
@@ -31,15 +31,11 @@ class WaveformLoader(WaveformSampler):
     ) -> None:
         super().__init__(*args, **kwargs)
         if training_waveform_path.is_dir():
-            self.training_waveform_files = list(
-                training_waveform_path.iterdir()
-            )
+            self.training_waveform_files = list(training_waveform_path.iterdir())
         else:
             self.training_waveform_files = [training_waveform_path]
 
-        waveform_set = WaveformPolarizationSet.read(
-            self.training_waveform_files[0]
-        )
+        waveform_set = WaveformPolarizationSet.read(self.training_waveform_files[0])
         if waveform_set.right_pad != self.right_pad:
             raise ValueError(
                 "Training waveform file does not have the same "
@@ -90,7 +86,7 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
         batch_size: int,
         batches_per_epoch: int,
         chunk_size: int = 1000,
-        path: Optional[Path] = None,
+        path: Optional[Path | str] = None,
     ):
         self.fnames = fnames
         self.channels = channels
@@ -99,7 +95,7 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
         self.chunk_size = chunk_size
 
         if path is not None:
-            self.path = path.parts
+            self.path = path.parts if isinstance(path, Path) else path.split("/")
         else:
             self.path = None
 
@@ -121,9 +117,7 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
 
             pm_grp = f["parameters"]
             self.param_keys = list(pm_grp.keys())
-            self.param_datasets[fname] = {
-                k: pm_grp[k] for k in self.param_keys
-            }
+            self.param_datasets[fname] = {k: pm_grp[k] for k in self.param_keys}
 
             # store sizes of each dataset and warn if not chunked;
             # assumes all dsets have same attributes
@@ -136,9 +130,7 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
                     "without using chunked storage. This can have "
                     "severe performance impacts at data loading time. "
                     "If you need faster loading, try re-generating "
-                    "your datset with chunked storage turned on.".format(
-                        fnames
-                    ),
+                    "your datset with chunked storage turned on.".format(fnames),
                     stacklevel=2,
                 )
 
@@ -178,17 +170,12 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
             channel: self.mmap_datasets[fname][channel][start:end]
             for channel in self.channels
         }
-        params = {
-            k: self.param_datasets[fname][k][start:end]
-            for k in self.param_keys
-        }
+        params = {k: self.param_datasets[fname][k][start:end] for k in self.param_keys}
         return waveforms, params
 
     def sample_batch(self):
         # allocate batch up front
-        batch = np.zeros(
-            (self.batch_size, self.num_channels, self.waveform_size)
-        )
+        batch = np.zeros((self.batch_size, self.num_channels, self.waveform_size))
         params_buf = {
             k: np.zeros(
                 self.batch_size,
@@ -200,9 +187,7 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
         for i in range(self.chunks_per_batch):
             fname = np.random.choice(self.fnames, p=self.probs)
 
-            chunk_size = min(
-                self.chunk_size, self.batch_size - i * self.chunk_size
-            )
+            chunk_size = min(self.chunk_size, self.batch_size - i * self.chunk_size)
 
             # select a random starting index for the chunk
             max_start = self.sizes[fname] - chunk_size
@@ -269,9 +254,7 @@ class ChunkedWaveformDataset(torch.utils.data.IterableDataset):
 
         def _next(it):
             [waveform_chunk], param_dict_chunk = next(it)
-            return waveform_chunk, {
-                k: v[0] for k, v in param_dict_chunk.items()
-            }
+            return waveform_chunk, {k: v[0] for k, v in param_dict_chunk.items()}
 
         waveform_chunk, param_chunk = _next(it)
         num_waveforms, _, _ = waveform_chunk.shape

--- a/projects/train/train/data/waveforms/loader.py
+++ b/projects/train/train/data/waveforms/loader.py
@@ -90,7 +90,7 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
         batch_size: int,
         batches_per_epoch: int,
         chunk_size: int = 1000,
-        path: Optional[Path] = None,
+        path: Optional[Path | str] = None,
     ):
         self.fnames = fnames
         self.channels = channels
@@ -99,7 +99,7 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
         self.chunk_size = chunk_size
 
         if path is not None:
-            self.path = path.parts
+            self.path = Path(path).parts
         else:
             self.path = None
 
@@ -112,6 +112,7 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
         # of interest in a dictionary so we
         # can access them at will without needing
         # to reopen the files each time
+        self.param_keys = None
         for fname in self.fnames:
             f, g = self.open(fname)
             self.mmap_files[fname] = f
@@ -120,7 +121,14 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
             }
 
             pm_grp = f["parameters"]
-            self.param_keys = list(pm_grp.keys())
+            keys = list(pm_grp.keys())
+            if self.param_keys is None:
+                self.param_keys = keys
+            elif set(keys) != set(self.param_keys):
+                raise ValueError(
+                    f"Parameter keys in {fname} ({keys}) do not match "
+                    f"those in the first file ({self.param_keys})"
+                )
             self.param_datasets[fname] = {
                 k: pm_grp[k] for k in self.param_keys
             }

--- a/projects/train/train/data/waveforms/loader.py
+++ b/projects/train/train/data/waveforms/loader.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import logging
 import math
 import warnings
-from typing import Iterable, Optional
+from typing import Sequence, Optional
 
 import h5py
 import numpy as np
@@ -85,8 +85,8 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
 
     def __init__(
         self,
-        fnames: Iterable[Path],
-        channels: Iterable[str],
+        fnames: Sequence[Path],
+        channels: Sequence[str],
         batch_size: int,
         batches_per_epoch: int,
         chunk_size: int = 1000,
@@ -99,13 +99,14 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
         self.chunk_size = chunk_size
 
         if path is not None:
-            self.path = path.split("/")
+            self.path = path.parts
         else:
             self.path = None
 
         self.sizes = {}
         self.mmap_files = {}
         self.mmap_datasets = {}
+        self.param_datasets = {}
 
         # for each file store the datasets
         # of interest in a dictionary so we
@@ -116,6 +117,12 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
             self.mmap_files[fname] = f
             self.mmap_datasets[fname] = {
                 channel: g[channel] for channel in self.channels
+            }
+
+            pm_grp = f["parameters"]
+            self.param_keys = list(pm_grp.keys())
+            self.param_datasets[fname] = {
+                k: pm_grp[k] for k in self.param_keys
             }
 
             # store sizes of each dataset and warn if not chunked;
@@ -167,16 +174,28 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
 
     def load_chunk(self, fname, start, size):
         end = min(start + size, self.sizes[fname])
-        return {
+        waveforms = {
             channel: self.mmap_datasets[fname][channel][start:end]
             for channel in self.channels
         }
+        params = {
+            k: self.param_datasets[fname][k][start:end]
+            for k in self.param_keys
+        }
+        return waveforms, params
 
     def sample_batch(self):
         # allocate batch up front
         batch = np.zeros(
             (self.batch_size, self.num_channels, self.waveform_size)
         )
+        params_buf = {
+            k: np.zeros(
+                self.batch_size,
+                dtype=self.param_datasets[self.fnames[0]][k].dtype,
+            )
+            for k in self.param_keys
+        }
 
         for i in range(self.chunks_per_batch):
             fname = np.random.choice(self.fnames, p=self.probs)
@@ -190,14 +209,20 @@ class Hdf5WaveformLoader(torch.utils.data.IterableDataset):
             start = np.random.randint(0, max_start + 1)
 
             # load the chunk and insert it into the batch
-            chunk = self.load_chunk(fname, start, chunk_size)
+            wf_chunk, param_chunk = self.load_chunk(fname, start, chunk_size)
+
             batch_start = i * self.chunk_size
             batch_end = batch_start + chunk_size
 
-            for i, channel in enumerate(self.channels):
-                batch[batch_start:batch_end, i, :] = chunk[channel]
+            for k in self.param_keys:
+                params_buf[k][batch_start:batch_end] = param_chunk[k]
 
-        return torch.tensor(batch)
+            for j, channel in enumerate(self.channels):
+                batch[batch_start:batch_end, j, :] = wf_chunk[channel]
+
+        waveforms = torch.tensor(batch)
+        params = {k: torch.tensor(v) for k, v in params_buf.items()}
+        return waveforms, params
 
     def __iter__(self):
         for _ in range(self.batches_per_epoch):
@@ -227,7 +252,7 @@ class ChunkedWaveformDataset(torch.utils.data.IterableDataset):
 
     def __init__(
         self,
-        chunk_it: Iterable,
+        chunk_it: Sequence,
         batch_size: int,
         batches_per_chunk: int,
     ) -> None:
@@ -241,17 +266,27 @@ class ChunkedWaveformDataset(torch.utils.data.IterableDataset):
 
     def __iter__(self):
         it = iter(self.chunk_it)
-        [chunk] = next(it)
 
-        num_waveforms, _, _ = chunk.shape
+        def _next(it):
+            [waveform_chunk], param_dict_chunk = next(it)
+            return waveform_chunk, {
+                k: v[0] for k, v in param_dict_chunk.items()
+            }
+
+        waveform_chunk, param_chunk = _next(it)
+        num_waveforms, _, _ = waveform_chunk.shape
+
         while True:
             # generate batches from the current chunk
             for _ in range(self.batches_per_chunk):
                 idx = torch.randperm(num_waveforms)[: self.batch_size]
-                yield chunk[idx]
+                yield (
+                    waveform_chunk[idx],
+                    {k: v[idx] for k, v in param_chunk.items()},
+                )
 
             try:
-                [chunk] = next(it)
+                waveform_chunk, param_chunk = _next(it)
             except StopIteration:
                 break
-            num_waveforms, _, _ = chunk.shape
+            num_waveforms, _, _ = waveform_chunk.shape

--- a/projects/train/train/data/waveforms/sampler.py
+++ b/projects/train/train/data/waveforms/sampler.py
@@ -1,6 +1,8 @@
+from dataclasses import fields
 from pathlib import Path
 from typing import List
 
+import numpy as np
 import torch
 from utils import x_per_y
 
@@ -9,6 +11,7 @@ from ledger.injections import WaveformSet, waveform_class_factory
 Distribution = torch.distributions.Distribution
 
 
+# TODO: Make this class ABC?
 class WaveformSampler(torch.nn.Module):
     """
     Base object defining methods that waveform producing classes
@@ -60,15 +63,33 @@ class WaveformSampler(torch.nn.Module):
 
     # Assuming that we're going to be loading validation waveforms
     # from disk for now, so this function can be defined here.
-    def get_val_waveforms(self, world_size, rank):
-        """
-        Returns validation waveforms for this device
+    def get_val_waveforms(
+        self, world_size, rank
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        """Returns validation waveforms and injection parameters
+        for this device.
+
+        Returns:
+            Tuple of (waveforms, params) where waveforms has shape
+            ``(N, num_ifos, T)`` and params is a dict mapping each
+            scalar injection parameter name to a tensor of
+            shape ``(N, ...)``.
         """
         start, stop = self.get_slice_bounds(
             self.num_val_waveforms, world_size, rank
         )
         waveform_set = self.waveform_set_cls.read(self.val_waveform_file)
-        return torch.Tensor(waveform_set.waveforms[start:stop])
+        waveforms = torch.Tensor(waveform_set.waveforms[start:stop])
+
+        params: dict[str, torch.Tensor] = {}
+        for f in fields(waveform_set):
+            if f.metadata.get("kind") != "parameter":
+                continue
+            val = getattr(waveform_set, f.name)
+            if isinstance(val, np.ndarray):
+                params[f.name] = torch.from_numpy(val[start:stop])
+
+        return waveforms, params
 
     def get_test_waveforms(self):
         raise NotImplementedError

--- a/projects/train/train/model/__init__.py
+++ b/projects/train/train/model/__init__.py
@@ -1,5 +1,8 @@
 from .autoencoder import AutoencoderAframe
 from .base import AframeBase
+from .classification import AframeClassification
+from .multitask import SupervisedMultiTaskAframe
+from .regression import SupervisedRegressionAframe
 from .supervised import (
     SupervisedAframe,
     SupervisedAframeS4,

--- a/projects/train/train/model/autoencoder.py
+++ b/projects/train/train/model/autoencoder.py
@@ -2,12 +2,12 @@ import torch
 from architectures.autoencoder import AutoencoderArchitecture
 from ml4gw.transforms import ShiftedPearsonCorrelation
 
-from train.model.base import AframeBase
+from train.model.classification import AframeClassification
 
 Tensor = torch.Tensor
 
 
-class AutoencoderAframe(AframeBase):
+class AutoencoderAframe(AframeClassification):
     # TODO: include extra init arguments for the
     # various loss terms we might like to include.
     # If specific architectures have loss functions

--- a/projects/train/train/model/base.py
+++ b/projects/train/train/model/base.py
@@ -37,7 +37,7 @@ class AframeBase(pl.LightningModule):
         self.model = arch
         self.verbose = verbose
         self._logger = self.init_logging(verbose)
-        self.save_hyperparameters(ignore=["arch"])
+        self.save_hyperparameters(ignore=["arch", "metric"])
 
     def init_logging(self, verbose):
         log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/projects/train/train/model/base.py
+++ b/projects/train/train/model/base.py
@@ -6,8 +6,6 @@ import lightning.pytorch as pl
 import torch
 from architectures import Architecture
 
-from train.metrics import TimeSlideAUROC
-
 Tensor = torch.Tensor
 
 
@@ -15,40 +13,31 @@ class AframeBase(pl.LightningModule):
     """
     Args:
         arch: Architecture to train on
-        metric: Metric used for evaluation
         learning_rate:
             Hyperparameter controlling size of gradient steps
             during training
         pct_lr_ramp:
             Fraction of number of training epochs over which
             learning rate will ramp up to its specified value
-        patience:
-            Number of epochs to wait for an increase in
-            validation AUROC before terminating training.
-            If left as `None`, will never terminate
-            training early
-        save_top_k_models:
-            Maximum number of best-performing model checkpoints
-            to keep during training
+        weight_decay:
+            L2 regularisation strength
+        verbose:
+            Enable debug-level logging
     """
 
     def __init__(
         self,
         arch: Architecture,
-        metric: TimeSlideAUROC,
         learning_rate: float,
         pct_lr_ramp: float,
         weight_decay: float = 0.0,
         verbose: bool = False,
     ) -> None:
         super().__init__()
-        # construct our model up front and record all
-        # our hyperparameters to our logdir;
         self.model = arch
-        self.metric = metric
         self.verbose = verbose
         self._logger = self.init_logging(verbose)
-        self.save_hyperparameters(ignore=["arch", "metric"])
+        self.save_hyperparameters(ignore=["arch"])
 
     def init_logging(self, verbose):
         log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
@@ -149,7 +138,7 @@ class AframeBase(pl.LightningModule):
         if isinstance(loss, dict):
             for name, value in loss.items():
                 self.log(
-                    name,
+                    f"train/{name}",
                     value.mean(),
                     on_step=True,
                     on_epoch=True,
@@ -160,7 +149,7 @@ class AframeBase(pl.LightningModule):
 
         loss = loss.mean()
         self.log(
-            "train_loss",
+            "train/loss",
             loss,
             on_step=True,
             on_epoch=True,
@@ -168,36 +157,6 @@ class AframeBase(pl.LightningModule):
             logger=True,
         )
         return loss
-
-    def validation_step(self, batch, _) -> None:
-        shift, X_bg, X_inj, params = batch
-
-        y_bg = self.score(X_bg)
-
-        # compute predictions over multiple views of
-        # each injection and use their average as our
-        # prediction
-        num_views, batch, *shape = X_inj.shape
-        X_inj = X_inj.view(num_views * batch, *shape)
-        y_fg = self.score(X_inj)
-        y_fg = y_fg.view(num_views, batch)
-        y_fg = y_fg.mean(0)
-
-        # include the shift associated with this data
-        # in our outputs to reconstruct background
-        # timeseries at aggregation time
-        self.metric.update(shift, y_bg, y_fg)
-
-        # lightning will take care of updating then
-        # computing the metric at the end of the
-        # validation epoch
-        self.log(
-            "valid_auroc",
-            self.metric,
-            on_step=True,
-            on_epoch=True,
-            sync_dist=True,
-        )
 
     def configure_optimizers(self):
         if not torch.distributed.is_initialized():

--- a/projects/train/train/model/base.py
+++ b/projects/train/train/model/base.py
@@ -170,7 +170,7 @@ class AframeBase(pl.LightningModule):
         return loss
 
     def validation_step(self, batch, _) -> None:
-        shift, X_bg, X_inj = batch
+        shift, X_bg, X_inj, params = batch
 
         y_bg = self.score(X_bg)
 

--- a/projects/train/train/model/classification.py
+++ b/projects/train/train/model/classification.py
@@ -1,0 +1,51 @@
+from architectures import Architecture
+
+from train.metrics import TimeSlideAUROC
+from train.model.base import AframeBase
+import torch
+
+Tensor = torch.Tensor
+
+
+class AframeClassification(AframeBase):
+    """
+    Extends AframeBase with a TimeSlideAUROC validation step.
+
+    All detection-oriented models (supervised, autoencoder, multi-task)
+    should inherit from this class.
+
+    Args:
+        arch: Architecture to train on.
+        metric: TimeSlideAUROC instance used to evaluate detection performance.
+    """
+
+    def __init__(
+        self,
+        arch: Architecture,
+        metric: TimeSlideAUROC,
+        *args,
+        **kwargs,
+    ) -> None:
+        super().__init__(arch, *args, **kwargs)
+        self.metric = metric
+
+    def validation_step(self, batch, _) -> None:
+        shift, X_bg, X_inj, params = batch
+
+        y_bg = self.score(X_bg)
+
+        num_views, batch_size, *shape = X_inj.shape
+        X_inj = X_inj.view(num_views * batch_size, *shape)
+        y_fg = self.score(X_inj)
+        y_fg = y_fg.view(num_views, batch_size).mean(0)
+
+        self.metric.update(shift, y_bg, y_fg)
+
+        metric_name = self.metric.__class__.__name__
+        self.log(
+            f"validation/{metric_name}",
+            self.metric,
+            on_step=True,
+            on_epoch=True,
+            sync_dist=True,
+        )

--- a/projects/train/train/model/multitask.py
+++ b/projects/train/train/model/multitask.py
@@ -1,0 +1,70 @@
+from typing import List
+
+import torch
+import torch.nn.functional as F
+from architectures import Architecture
+
+from train.metrics import TimeSlideAUROC
+from train.model.supervised import SupervisedAframe
+
+Tensor = torch.Tensor
+
+
+class SupervisedMultiTaskAframe(SupervisedAframe):
+    """
+    Multi-task model that jointly optimizes binary classification
+    and injection parameter regression.
+
+    The architecture's forward pass must return a tuple
+    ``(logits, param_estimates)`` where ``logits`` has shape ``(N, 1)``
+    and ``param_estimates`` has shape ``(N, len(param_names))``.
+
+    Validation uses the standard AUROC metric on the classification head,
+    so the existing validation infrastructure is fully reused.
+
+    Args:
+        arch:
+            Architecture whose forward pass returns (logits, param_estimates).
+        param_names:
+            Ordered list of parameter names to regress on. Must match the
+            output ordering of the architecture's regression head.
+        regression_weight:
+            Scalar multiplier applied to the regression loss before summing
+            with the classification loss.
+    """
+
+    def __init__(
+        self,
+        arch: Architecture,
+        metric: TimeSlideAUROC,
+        param_names: List[str],
+        *args,
+        regression_weight: float = 1.0,
+        **kwargs,
+    ):
+        super().__init__(arch, metric, *args, **kwargs)
+        self.param_names = param_names
+        self.regression_weight = regression_weight
+
+    def score(self, X: Tensor) -> Tensor:
+        logits, _ = self(X)
+        return logits
+
+    def train_step(self, batch):
+        X, y, params = batch
+        logits, param_estimates = self(X)
+
+        clf_loss = F.binary_cross_entropy_with_logits(logits, y)
+
+        targets = torch.stack([params[k] for k in self.param_names], dim=1)
+        mask = ~torch.isnan(targets).any(dim=1)
+        reg_loss = (
+            F.mse_loss(param_estimates[mask], targets[mask])
+            if mask.any()
+            else torch.zeros(1, device=X.device)
+        )
+
+        return {"classification_loss": clf_loss, "regression_loss": reg_loss}
+
+    def compute_loss_fn(self, classification_loss, regression_loss):
+        return classification_loss + self.regression_weight * regression_loss

--- a/projects/train/train/model/regression.py
+++ b/projects/train/train/model/regression.py
@@ -1,0 +1,85 @@
+from typing import List
+import warnings
+import torch
+import torch.nn.functional as F
+from architectures import Architecture
+
+
+from train.model.base import AframeBase
+
+Tensor = torch.Tensor
+
+
+class SupervisedRegressionAframe(AframeBase):
+    """
+    Supervised model that predicts injection parameters via regression only,
+    with no classification head or detection objective.
+
+    Designed to be used with ``waveform_prob=1.0`` so that every training
+    sample contains an injection. Non-injected samples (NaN params) are
+    masked out of the loss gracefully, but they are wasteful.
+
+    For validation set ``num_valid_views=1`` in the data config — multiple
+    views are only meaningful for averaging detection scores, not for
+    parameter recovery.
+
+    The architecture's forward pass must return ``param_estimates`` of
+    shape ``(N, len(param_names))``.
+
+    Args:
+        arch:
+            Architecture whose forward pass returns param_estimates.
+        param_names:
+            Ordered list of parameter names to regress on. Must match
+            the output ordering of the architecture's regression head.
+    """
+
+    def __init__(
+        self,
+        arch: Architecture,
+        param_names: List[str],
+        **kwargs,
+    ):
+        super().__init__(arch=arch, **kwargs)
+        self.param_names = param_names
+
+    def forward(self, X: Tensor) -> Tensor:
+        return self.model(X)
+
+    def score(self, X: Tensor) -> Tensor:
+        return self(X)
+
+    def train_step(self, batch):
+        X, y, params = batch
+        mask = ~torch.isnan(next(iter(params.values())))
+
+        if not mask.any():
+            warnings.warn(
+                "All samples in batch have NaN parameters;"
+                "skipping regression step.",
+                stacklevel=2,
+            )
+            return torch.zeros(1, device=X.device, requires_grad=True)
+
+        targets = torch.stack(
+            [params[k][mask] for k in self.param_names], dim=1
+        )
+        return F.mse_loss(self(X[mask]), targets)
+
+    def validation_step(self, batch, _):
+        _, _, X_inj, params = batch
+        num_views, N, *shape = X_inj.shape
+        X_inj = X_inj.view(num_views * N, *shape)
+
+        param_estimates = self(X_inj)
+
+        for i, name in enumerate(self.param_names):
+            targets = params[name].repeat(num_views)
+            mae = F.l1_loss(param_estimates[:, i], targets)
+            self.log(
+                f"validation/mae_{name}",
+                mae,
+                on_step=False,
+                on_epoch=True,
+                sync_dist=True,
+            )

--- a/projects/train/train/model/supervised.py
+++ b/projects/train/train/model/supervised.py
@@ -14,8 +14,8 @@ class SupervisedAframe(AframeBase):
     def forward(self, X):
         return self.model(X)
 
-    def train_step(self, batch: tuple[Tensor, Tensor]) -> Tensor:
-        X, y = batch
+    def train_step(self, batch: tuple[Tensor, Tensor, dict]) -> Tensor:
+        X, y, params = batch
         y_hat = self(X)
         return torch.nn.functional.binary_cross_entropy_with_logits(y_hat, y)
 
@@ -33,13 +33,13 @@ class SupervisedMultiModalAframe(SupervisedAframe):
     def score(self, X, X_fft):
         return self(X, X_fft)
 
-    def train_step(self, batch: tuple[Tensor, Tensor]) -> Tensor:
-        (X, X_fft), y = batch
+    def train_step(self, batch: tuple[Tensor, Tensor, dict]) -> Tensor:
+        (X, X_fft), y, params = batch
         y_hat = self(X, X_fft)
         return torch.nn.functional.binary_cross_entropy_with_logits(y_hat, y)
 
     def validation_step(self, batch, _) -> None:
-        shift, (X_bg, X_bg_fft), (X_inj, X_inj_fft) = batch
+        shift, (X_bg, X_bg_fft), (X_inj, X_inj_fft), params = batch
 
         y_bg = self.score(X_bg, X_bg_fft)
 
@@ -102,9 +102,9 @@ class SupervisedTimeSpectrogramAframe(SupervisedAframe):
         return self(X, X_spec)
 
     def train_step(
-        self, batch: tuple[tuple[Tensor, Tensor], Tensor]
+        self, batch: tuple[tuple[Tensor, Tensor], Tensor, dict]
     ) -> Tensor | dict[str, Tensor]:
-        (X, X_spec), y = batch
+        (X, X_spec), y, params = batch
         y_hat_X, y_hat_X_spec = self(X, X_spec)
         loss_X = torch.nn.functional.binary_cross_entropy_with_logits(
             y_hat_X, y
@@ -124,7 +124,7 @@ class SupervisedTimeSpectrogramAframe(SupervisedAframe):
         )
 
     def validation_step(self, batch, _) -> None:
-        shift, (X_bg, X_bg_spec), (X_fg, X_fg_spec) = batch
+        shift, (X_bg, X_bg_spec), (X_fg, X_fg_spec), params = batch
 
         y_bg_X, y_bg_spec = self.score(X_bg, X_bg_spec)
         y_bg = (self.val_X_coeff * y_bg_X) + (

--- a/projects/train/train/model/supervised.py
+++ b/projects/train/train/model/supervised.py
@@ -1,13 +1,13 @@
 import torch
 from architectures.supervised import SupervisedArchitecture
 
-from train.model.base import AframeBase
+from train.model.classification import AframeClassification
 from train.metrics import TimeSlideAUROC
 
 Tensor = torch.Tensor
 
 
-class SupervisedAframe(AframeBase):
+class SupervisedAframe(AframeClassification):
     def __init__(self, arch: SupervisedArchitecture, *args, **kwargs) -> None:
         super().__init__(arch, *args, **kwargs)
 

--- a/projects/train/train/transforms.py
+++ b/projects/train/train/transforms.py
@@ -1,0 +1,21 @@
+import torch
+
+Tensor = torch.Tensor
+
+
+class ChirpMass:
+    """Adds ``chirp_mass`` computed from ``mass_1`` and ``mass_2``."""
+
+    def __call__(self, params: dict[str, Tensor]) -> dict[str, Tensor]:
+        m1, m2 = params["mass_1"], params["mass_2"]
+        params["chirp_mass"] = (m1 * m2) ** 0.6 / (m1 + m2) ** 0.2
+        return params
+
+
+class MassRatio:
+    """Adds ``mass_ratio`` = min(m1,m2) / max(m1,m2) in range (0, 1]."""
+
+    def __call__(self, params: dict[str, Tensor]) -> dict[str, Tensor]:
+        m1, m2 = params["mass_1"], params["mass_2"]
+        params["mass_ratio"] = torch.minimum(m1, m2) / torch.maximum(m1, m2)
+        return params


### PR DESCRIPTION
> [!WARNING]
> Work in Progress
 
This PR builds on top of https://github.com/ML4GW/aframe/pull/451 (most of the changes are from there) and adds two training tasks:

- regression: `projects/train/train/model/regression.py`; Designed to be used with `waveform_prob=1.0`
- multitask: in `projects/train/train/model/multitask.py`; Both regression and classification at the same time. So have a regression and a classification head on the same model.

The `AframeBase` model base class in `projects/train/train/model/base.py` is refactored to be a general base class for all task types. `projects/train/train/model/{classification|regression|multitask}.py` inherit from `AframeBase` and implement specifics for each task.

The two configs in `projects/train/configs/regression/` show how to setup the two respective models. Before merging I would remove/refactor these similar to the other training configs. 