### PR TITLE
Aggregate train

### DIFF
--- a/pipeline/config/config.yaml
+++ b/pipeline/config/config.yaml
@@ -66,6 +66,9 @@ num_training_signals: 100000
 # Pre-generate training waveforms to disk instead of sampling them
 # on the fly during training.
 pregenerate_training_waveforms: true
+# Number of condor jobs that training waveforms are split across when
+# pregenerate_training_waveforms is true.
+num_training_jobs: 100
 
 # --- Testing / validation waveforms ------------------------------------------
 num_testing_signals: 500000

--- a/pipeline/config/config.yaml
+++ b/pipeline/config/config.yaml
@@ -68,7 +68,7 @@ num_training_signals: 100000
 pregenerate_training_waveforms: true
 # Number of condor jobs that training waveforms are split across when
 # pregenerate_training_waveforms is true.
-num_training_jobs: 100
+num_train_waveform_jobs: 100
 
 # --- Testing / validation waveforms ------------------------------------------
 num_testing_signals: 500000

--- a/pipeline/profiles/condor/config.yaml
+++ b/pipeline/profiles/condor/config.yaml
@@ -87,8 +87,10 @@ set-resources:
     request_memory: 2GB
   aggregate_val_waveforms:
     request_memory: 2GB
-  training_waveforms:
-    request_memory: 40GB
+  training_waveforms_branch:
+    request_memory: 2GB
+  aggregate_training_waveforms:
+    request_memory: 2GB
   infer_branch:
     request_memory: 8GB
   aggregate_infer:

--- a/projects/data/data.smk
+++ b/projects/data/data.smk
@@ -10,7 +10,8 @@ Rules:
   aggregate_val_waveforms       merge per-branch validation waveforms
   testing_waveforms_branch      testing waveforms for one branch
   aggregate_testing_waveforms   merge per-branch testing waveforms
-  training_waveforms            training waveform polarizations (optional)
+  training_waveforms_branch     one branch of training waveform polarizations (optional)
+  aggregate_training_waveforms  merge per-branch training waveforms (optional)
 
 Directory layout:
 
@@ -44,6 +45,9 @@ DATA_CONTAINER = os.path.join(os.getenv("AFRAME_CONTAINER_ROOT", ""), "data.sif"
 num_validation_jobs = int(config.get("num_validation_jobs", 200))
 validation_branch_ids = [str(i) for i in range(num_validation_jobs)]
 
+num_training_jobs = int(config.get("num_training_jobs", 10))
+training_branch_ids = [str(i) for i in range(num_training_jobs)]
+
 
 localrules:
     compute_waveform_branches,
@@ -54,6 +58,7 @@ wildcard_constraints:
     duration=r"\d+",
     wbranch_id=r"\d+",
     vbranch_id=r"\d+",
+    tbranch_id=r"\d+",
 
 
 def _fmt_list(values):
@@ -404,14 +409,13 @@ rule aggregate_testing_waveforms:
 rule val_waveforms_branch:
     """Generate one branch of validation waveforms via rejection sampling.
 
-num_validation_signals is split evenly across num_validation_jobs
-branches.  The PSD reference is the last fetched train-background
-chunk, matching the law DeployValidationWaveforms task.
+num_validation_signals is split evenly across num_validation_jobs branches.
+The PSD reference is the last fetched train-background chunk.
 """
     input:
         psd_file=_train_psd_file,
     output:
-        str(train_waveforms / "tmp" / "waveforms-{vbranch_id}.hdf5"),
+        str(train_waveforms / "validation_tmp" / "waveforms-{vbranch_id}.hdf5"),
     log:
         str(data_log_dir / "val_waveforms_branch-{vbranch_id}.log"),
     container:
@@ -454,7 +458,7 @@ rule aggregate_val_waveforms:
     """Merge per-branch validation waveforms into val_waveforms.hdf5."""
     input:
         expand(
-            str(train_waveforms / "tmp" / "waveforms-{vbranch_id}.hdf5"),
+            str(train_waveforms / "validation_tmp" / "waveforms-{vbranch_id}.hdf5"),
             vbranch_id=validation_branch_ids,
         ),
     output:
@@ -465,23 +469,26 @@ rule aggregate_val_waveforms:
         DATA_CONTAINER
     params:
         ifos=config["ifos"],
-        tmp_dir=str(train_waveforms / "tmp"),
+        tmp_dir=str(train_waveforms / "validation_tmp"),
     script:
         "scripts/aggregate_val_waveforms.py"
 
 
 if config.get("pregenerate_training_waveforms", False):
 
-    rule training_waveforms:
-        """Pre-generate training waveform polarizations to disk."""
+    rule training_waveforms_branch:
+        """Generate one branch of training waveform polarizations.
+
+        num_training_signals is split evenly across num_training_jobs branches.
+        """
         output:
-            str(train_waveforms / "training_waveforms.hdf5"),
+            str(train_waveforms / "training_tmp" / "{tbranch_id}.hdf5"),
         log:
-            str(data_log_dir / "training_waveforms.log"),
+            str(data_log_dir / "training_waveforms_branch-{tbranch_id}.log"),
         container:
             DATA_CONTAINER
         params:
-            num_signals=config["num_training_signals"],
+            num_signals=math.ceil(config["num_training_signals"] / num_training_jobs),
             sample_rate=config["sample_rate"],
             waveform_duration=config["waveform_duration"],
             prior=config["prior"],
@@ -501,3 +508,21 @@ if config.get("pregenerate_training_waveforms", False):
             " --right_pad {params.right_pad}"
             " --output_file {output}"
             " &> {log}"
+
+    rule aggregate_training_waveforms:
+        """Merge per-branch training waveforms into training_waveforms.hdf5."""
+        input:
+            expand(
+                str(train_waveforms / "training_tmp" / "{tbranch_id}.hdf5"),
+                tbranch_id=training_branch_ids,
+            ),
+        output:
+            str(train_waveforms / "training_waveforms.hdf5"),
+        log:
+            str(data_log_dir / "aggregate_training_waveforms.log"),
+        container:
+            DATA_CONTAINER
+        params:
+            tmp_dir=str(train_waveforms / "training_tmp"),
+        script:
+            "scripts/aggregate_training_waveforms.py"

--- a/projects/data/data.smk
+++ b/projects/data/data.smk
@@ -45,8 +45,8 @@ DATA_CONTAINER = os.path.join(os.getenv("AFRAME_CONTAINER_ROOT", ""), "data.sif"
 num_validation_jobs = int(config.get("num_validation_jobs", 200))
 validation_branch_ids = [str(i) for i in range(num_validation_jobs)]
 
-num_training_jobs = int(config.get("num_training_jobs", 10))
-training_branch_ids = [str(i) for i in range(num_training_jobs)]
+num_train_waveform_jobs = int(config.get("num_train_waveform_jobs", 10))
+training_branch_ids = [str(i) for i in range(num_train_waveform_jobs)]
 
 
 localrules:
@@ -479,7 +479,7 @@ if config.get("pregenerate_training_waveforms", False):
     rule training_waveforms_branch:
         """Generate one branch of training waveform polarizations.
 
-        num_training_signals is split evenly across num_training_jobs branches.
+        num_training_signals is split evenly across num_train_waveform_jobs branches.
         """
         output:
             str(train_waveforms / "training_tmp" / "{tbranch_id}.hdf5"),
@@ -488,7 +488,9 @@ if config.get("pregenerate_training_waveforms", False):
         container:
             DATA_CONTAINER
         params:
-            num_signals=math.ceil(config["num_training_signals"] / num_training_jobs),
+            num_signals=math.ceil(
+                config["num_training_signals"] / num_train_waveform_jobs
+            ),
             sample_rate=config["sample_rate"],
             waveform_duration=config["waveform_duration"],
             prior=config["prior"],

--- a/projects/data/scripts/aggregate_training_waveforms.py
+++ b/projects/data/scripts/aggregate_training_waveforms.py
@@ -1,0 +1,22 @@
+# ruff: noqa: F821
+"""Merge per-branch training waveform files into training_waveforms.hdf5.
+
+Executed via the snakemake `script:` directive.
+The `snakemake` object is injected by snakemake.
+"""
+
+import shutil
+import sys
+from pathlib import Path
+
+from ledger.injections import WaveformPolarizationSet
+
+sys.stdout = sys.stderr = open(snakemake.log[0], "w", buffering=1)
+
+WaveformPolarizationSet.aggregate(
+    [Path(i) for i in list(snakemake.input)],
+    snakemake.output[0],
+    clean=True,
+)
+
+shutil.rmtree(snakemake.params.tmp_dir, ignore_errors=True)

--- a/projects/train/train.yaml
+++ b/projects/train/train.yaml
@@ -107,14 +107,17 @@ data:
     num_valid_views: 5
     valid_livetime: 57600 
 trainer:
-  # by default, use a local CSV logger.
-  # Options in train task for using a
-  # wandb logger instead
+  # W&B alternative:
+  # logger:
+  #   class_path: lightning.pytorch.loggers.WandbLogger
+  #   init_args:
+  #     project: aframe
+  #     name: my-run
   logger:
-    - class_path: lightning.pytorch.loggers.CSVLogger
-      init_args:
-        # save_dir:
-        flush_logs_every_n_steps: 10
+    class_path: lightning.pytorch.loggers.CSVLogger
+    init_args:
+      name: lightning_logs
+      flush_logs_every_n_steps: 10
   callbacks:
     # Uncomment below if you want to stop early based on validation score
     # - class_path: lightning.pytorch.callbacks.EarlyStopping

--- a/scripts/aframe_init.py
+++ b/scripts/aframe_init.py
@@ -104,6 +104,20 @@ def write_content(content: str, path: Path):
     return content
 
 
+def create_snakemake_runfile(path: Path, profile: str):
+    config = path / "config.yaml"
+    cmd = f"snakemake --configfile {config} --profile {profile}"
+    content = f"""
+    #!/bin/bash
+    # Set AFRAME_DEV=1 to bind the working tree into containers.
+    cd {root}
+    source pipeline/.env
+    {cmd}
+    """
+    runfile = path / "run.sh"
+    write_content(content, runfile)
+
+
 def create_online_runfile(path: Path):
     cmd = "apptainer run --nv "
     # bind /local/aframe for finding scitokens
@@ -245,6 +259,18 @@ def main():
     offline_parser.add_argument("--s3-bucket")
     offline_parser.add_argument("--weights-dir", type=Path)
 
+    # snakemake subcommand
+    snakemake_parser = ArgumentParser()
+    snakemake_parser.add_argument(
+        "-d", "--directory", type=Path, required=True
+    )
+    snakemake_parser.add_argument(
+        "--profile",
+        type=str,
+        default="pipeline/profiles/condor",
+        help="Path to the snakemake profile directory",
+    )
+
     # online subcommand
     online_parser = ArgumentParser()
     online_parser.add_argument("-d", "--directory", type=Path, required=True)
@@ -256,6 +282,7 @@ def main():
         "for running aframe offline and online pipelines."
     )
     subcommands = parser.add_subcommands()
+    subcommands.add_subcommand("snakemake", snakemake_parser)
     subcommands.add_subcommand("online", online_parser)
     subcommands.add_subcommand("offline", offline_parser)
 
@@ -263,14 +290,24 @@ def main():
     subcommand = args.subcommand
     args = getattr(args, args.subcommand)
     directory = args.directory.resolve()
-    weights_dir = args.weights_dir.resolve() if args.weights_dir else None
+    weights_dir = getattr(args, "weights_dir", None)
+    if weights_dir:
+        weights_dir = weights_dir.resolve()
 
     # Create the run directory and move in weights if specified
     directory.mkdir(parents=True, exist_ok=True)
     if weights_dir:
         shutil.copytree(weights_dir, directory / "training")
 
-    if subcommand == "offline":
+    if subcommand == "snakemake":
+        run_config = directory / "config.yaml"
+        run_config.write_text(
+            f"# Overrides for pipeline/config/config.yaml.\n"
+            f"run_dir: {directory}\n"
+        )
+        create_snakemake_runfile(directory, args.profile)
+
+    elif subcommand == "offline":
         if args.s3_bucket is not None and not args.s3_bucket.startswith(
             "s3://"
         ):

--- a/scripts/aframe_init.py
+++ b/scripts/aframe_init.py
@@ -300,10 +300,13 @@ def main():
         shutil.copytree(weights_dir, directory / "training")
 
     if subcommand == "snakemake":
+        train_yaml = root / "projects" / "train" / "train.yaml"
+        shutil.copy(train_yaml, directory / "train.yaml")
         run_config = directory / "config.yaml"
         run_config.write_text(
             f"# Overrides for pipeline/config/config.yaml.\n"
             f"run_dir: {directory}\n"
+            f"train_config: {directory / 'train.yaml'}\n"
         )
         create_snakemake_runfile(directory, args.profile)
 


### PR DESCRIPTION
A couple of pieces to finish off the main snakemake setup:
- Splits the training waveform generation over multiple condor jobs and adds an aggregation step.
- Adds a `aframe-init` subcommand to create run directory for the snakemake pipeline.

Built off of #495.