### PR TITLE
Snakemake R&P Inference

### DIFF
--- a/pipeline/config/config.yaml
+++ b/pipeline/config/config.yaml
@@ -113,6 +113,13 @@ remote_train: false
 # remote_waveforms_dir: s3://aframe/data/waveforms/train
 
 # --- Export & inference ------------------------------------------------------
+# Analysis type:
+#   - hdf5: timeslide background segments + injection set
+#   - rnp: Rates and Populations frames.
+analysis_type: hdf5
+# rnp_frame_dir: /path/to/rnp/frames   # required when analysis_type: rnp
+# rnp_channel: <channel>               # channel within the frames
+
 # Inference mode:
 #   - triton: Triton server on GPU + streaming CPU clients
 #   - inprocess: self-contained GPU jobs, model loaded locally per job

--- a/projects/infer/infer.smk
+++ b/projects/infer/infer.smk
@@ -39,11 +39,21 @@ if INFERENCE_BACKEND not in ("export", "compile", "aoti"):
         f"inference_backend must be 'export', 'compile', or 'aoti', got {INFERENCE_BACKEND}"
     )
 
+ANALYSIS_TYPE = config.get("analysis_type", "hdf5")
+if ANALYSIS_TYPE not in ("hdf5", "rnp"):
+    raise WorkflowError(f"analysis_type must be 'hdf5' or 'rnp', got {ANALYSIS_TYPE}")
+if ANALYSIS_TYPE == "rnp" and INFERENCE_MODE == "triton":
+    raise WorkflowError("analysis_type 'rnp' requires inference_mode 'inprocess'")
+
 INFER_CONTAINER = os.path.join(os.getenv("AFRAME_CONTAINER_ROOT", ""), "infer.sif")
 
 AOTI_PKG = str(export_out / "model_aoti.pt2")
 
 BRANCHES_PER_JOB = config.get("branches_per_job", 1)
+
+if ANALYSIS_TYPE == "rnp":
+    FRAME_DIR = config["rnp_frame_dir"]
+    CHANNEL = config["rnp_channel"]
 
 
 wildcard_constraints:
@@ -68,77 +78,100 @@ def get_infer_group_sentinels(wildcards):
     }
 
 
-checkpoint compute_branch_map:
-    """Enumerate (background file, shifts) inference branches.
+if ANALYSIS_TYPE == "rnp":
 
-The number of shift multiples is the minimum needed to accumulate
-Tb seconds of background livetime. Branches that are too short to
-analyze after shifting and PSD burn-in are dropped. Optionally
-includes zero-lag branches.
-"""
-    input:
-        background=get_test_background_files,
-        waveform_branch_map=str(test_waveforms / "waveform_branch_map.json"),
-    output:
-        str(infer_dir / "branch_map.json"),
-    run:
-        def _get_num_shifts(segments, Tb, shift, psd_length):
-            if Tb == 0:
-                return 0
-            livetime, num_shifts = 0, 0
-            durations = [stop - start - psd_length for start, stop in segments]
-            while livetime < Tb:
-                num_shifts += 1
-                for dur in durations:
-                    dur -= shift * num_shifts
-                    if dur > 0:
-                        livetime += dur
-            return num_shifts
+    checkpoint compute_branch_map:
+        """Enumerate R&P frame files as one branch each."""
+        output:
+            str(infer_dir / "branch_map.json"),
+        run:
+            files = sorted(str(p) for p in Path(FRAME_DIR).rglob("*.gwf"))
+            if not files:
+                raise WorkflowError(f"No .gwf frames found in {FRAME_DIR}")
+            shifts = [0.0] * len(config["ifos"])
+            branch_map = {
+                str(i): {"fname": f, "shifts": shifts} for i, f in enumerate(files)
+            }
+            Path(output[0]).parent.mkdir(parents=True, exist_ok=True)
+            with open(output[0], "w") as f:
+                json.dump(branch_map, f, indent=2)
 
-        shifts = config["shifts"]
-        psd_length = config["psd_length"]
-        segments = []
-        for fname in input.background:
-            start, duration = map(float, Path(fname).stem.split("-")[-2:])
-            segments.append((start, start + duration))
-        num_shifts = _get_num_shifts(
-            segments, config["Tb"], max(shifts), psd_length
-        )
-        with open(input.waveform_branch_map) as f:
-            wbmap = json.load(f)
-        max_waveform_shift = max(max(b["shifts"]) for b in wbmap.values())
-        num_waveform_shifts = max_waveform_shift / max(shifts)
-        if num_waveform_shifts > num_shifts:
-            raise WorkflowError(
-                f"num_testing_signals requires {num_waveform_shifts} shift "
-                f"multiples but Tb={config['Tb']} only covers {num_shifts}. "
-                f"Reduce num_testing_signals or increase Tb."
+else:
+
+    checkpoint compute_branch_map:
+        """Enumerate (background file, shifts) inference branches.
+
+        The number of shift multiples is the minimum needed to accumulate
+        Tb seconds of background livetime. Branches that are too short to
+        analyze after shifting and PSD burn-in are dropped. Optionally
+        includes zero-lag branches.
+        """
+        input:
+            background=get_test_background_files,
+            waveform_branch_map=str(test_waveforms / "waveform_branch_map.json"),
+        output:
+            str(infer_dir / "branch_map.json"),
+        run:
+            def _get_num_shifts(segments, Tb, shift, psd_length):
+                if Tb == 0:
+                    return 0
+                livetime, num_shifts = 0, 0
+                durations = [stop - start - psd_length for start, stop in segments]
+                while livetime < Tb:
+                    num_shifts += 1
+                    for dur in durations:
+                        dur -= shift * num_shifts
+                        if dur > 0:
+                            livetime += dur
+                return num_shifts
+
+            shifts = config["shifts"]
+            psd_length = config["psd_length"]
+            segments = []
+            for fname in input.background:
+                start, duration = map(float, Path(fname).stem.split("-")[-2:])
+                segments.append((start, start + duration))
+            num_shifts = _get_num_shifts(
+                segments, config["Tb"], max(shifts), psd_length
             )
-        branch_map, i = {}, 0
-        for fname, (start, stop) in zip(input.background, segments):
-            if zero_lag:
-                zero_shifts = [0] * len(shifts)
-                if _is_analyzeable_segment(start, stop, zero_shifts, psd_length):
-                    branch_map[str(i)] = {
-                        "fname": str(fname),
-                        "shifts": zero_shifts,
-                    }
-                    i += 1
-            for j in range(num_shifts):
-                shift = [(j + 1) * s for s in shifts]
-                if _is_analyzeable_segment(start, stop, shift, psd_length):
-                    branch_map[str(i)] = {
-                        "fname": str(fname),
-                        "shifts": shift,
-                    }
-                    i += 1
-        Path(output[0]).parent.mkdir(parents=True, exist_ok=True)
-        with open(output[0], "w") as f:
-            json.dump(branch_map, f, indent=2)
+            with open(input.waveform_branch_map) as f:
+                wbmap = json.load(f)
+            max_waveform_shift = max(max(b["shifts"]) for b in wbmap.values())
+            num_waveform_shifts = max_waveform_shift / max(shifts)
+            if num_waveform_shifts > num_shifts:
+                raise WorkflowError(
+                    f"num_testing_signals requires {num_waveform_shifts} shift "
+                    f"multiples but Tb={config['Tb']} only covers {num_shifts}. "
+                    f"Reduce num_testing_signals or increase Tb."
+                )
+            branch_map, i = {}, 0
+            for fname, (start, stop) in zip(input.background, segments):
+                if zero_lag:
+                    zero_shifts = [0] * len(shifts)
+                    if _is_analyzeable_segment(
+                        start, stop, zero_shifts, psd_length
+                    ):
+                        branch_map[str(i)] = {
+                            "fname": str(fname),
+                            "shifts": zero_shifts,
+                        }
+                        i += 1
+                for j in range(num_shifts):
+                    shift = [(j + 1) * s for s in shifts]
+                    if _is_analyzeable_segment(start, stop, shift, psd_length):
+                        branch_map[str(i)] = {
+                            "fname": str(fname),
+                            "shifts": shift,
+                        }
+                        i += 1
+            Path(output[0]).parent.mkdir(parents=True, exist_ok=True)
+            with open(output[0], "w") as f:
+                json.dump(branch_map, f, indent=2)
 
 
 _group_common_params = dict(
     branches_per_job=BRANCHES_PER_JOB,
+    analysis_type=ANALYSIS_TYPE,
     outdir_root=str(infer_dir / "tmp"),
     ifos="[" + ",".join(config["ifos"]) + "]",
     inference_sampling_rate=config["inference_sampling_rate"],
@@ -154,8 +187,9 @@ _GROUP_SHELL_SUFFIX = (
     " --branch_map {input.branch_map}"
     " --group_id {wildcards.group_id}"
     " --branches_per_job {params.branches_per_job}"
-    " --waveforms {input.waveforms}"
-    " --outdir_root {params.outdir_root}"
+    " --analysis_type {params.analysis_type}"
+    + ("" if ANALYSIS_TYPE == "rnp" else " --waveforms {input.waveforms}")
+    + " --outdir_root {params.outdir_root}"
     " '--ifos={params.ifos}'"
     " --inference_sampling_rate {params.inference_sampling_rate}"
     " --batch_size {params.batch_size}"
@@ -273,13 +307,18 @@ else:
 
     else:
         _artifact = str(train_out / "model_exported.pt2")
+    # Only hdf5 needs the test waveform set.
+    infer_local_inputs = dict(
+        branch_map=str(infer_dir / "branch_map.json"),
+        artifact=_artifact,
+    )
+    if ANALYSIS_TYPE == "hdf5":
+        infer_local_inputs["waveforms"] = str(test_waveforms / "waveforms.hdf5")
 
     rule infer_group:
         """Run a group of branches in-process on one GPU."""
         input:
-            branch_map=str(infer_dir / "branch_map.json"),
-            waveforms=str(test_waveforms / "waveforms.hdf5"),
-            artifact=_artifact,
+            **infer_local_inputs,
         output:
             touch(str(infer_dir / "tmp" / "groups" / "{group_id}.done")),
         log:
@@ -308,7 +347,9 @@ else:
             " --sample_rate {params.sample_rate}"
             " --kernel_length {params.kernel_length}"
             " --highpass {params.highpass}"
-            " --fftlength {params.fftlength}" + _GROUP_SHELL_SUFFIX
+            " --fftlength {params.fftlength}"
+            + (f" --channel {CHANNEL}" if ANALYSIS_TYPE == "rnp" else "")
+            + _GROUP_SHELL_SUFFIX
 
 
 rule aggregate_infer:
@@ -331,5 +372,6 @@ rule aggregate_infer:
         INFER_CONTAINER
     params:
         tmp_dir=str(infer_dir / "tmp"),
+        analysis_type=ANALYSIS_TYPE,
     script:
         "scripts/aggregate_infer.py"

--- a/projects/infer/infer/cli.py
+++ b/projects/infer/infer/cli.py
@@ -4,9 +4,11 @@ Two entry points:
     infer-triton: stream branches to a running Triton server.
     infer-local: run branches in-process on a GPU.
 
-Both use the same main.infer() loop with the same Sequence and
-Postprocessor, so outputs are identical and aggregate_infer is
-client agnostic.
+Both use the same main.infer() loop and Postprocessor, so outputs are
+identical and aggregate_infer is client agnostic.
+
+--analysis_type selects the Sequence: hdf5 (timeslide background + injections)
+or rnp (Rates and Populations frames).
 """
 
 import json
@@ -17,7 +19,7 @@ import jsonargparse
 import numpy as np
 from utils.logging import configure_logging
 
-from infer.data import Sequence
+from infer.data import Hdf5Sequence, RnPSequence
 from infer.main import infer
 from infer.postprocess import Postprocessor
 
@@ -53,16 +55,27 @@ def _write_outputs(outdir, results, seq, postproc, return_timeseries):
             )
 
 
-def _run_branch(client, cfg, background_fname, shifts, outdir, rate=None):
-    seq = Sequence(
-        background_fname,
-        cfg.waveforms,
-        cfg.ifos,
-        shifts,
-        cfg.inference_sampling_rate,
-        cfg.batch_size,
-        rate=rate,
-    )
+def _run_branch(client, cfg, branch, outdir, rate=None):
+    shifts = branch["shifts"]
+    if cfg.analysis_type == "rnp":
+        seq = RnPSequence(
+            injection_file=Path(branch["fname"]),
+            channel=cfg.channel,
+            ifos=cfg.ifos,
+            sample_rate=cfg.sample_rate,
+            inference_sampling_rate=cfg.inference_sampling_rate,
+            batch_size=cfg.batch_size,
+        )
+    else:
+        seq = Hdf5Sequence(
+            branch["fname"],
+            cfg.waveforms,
+            cfg.ifos,
+            shifts,
+            cfg.inference_sampling_rate,
+            cfg.batch_size,
+            rate=rate,
+        )
     client.callback = seq
     postproc = Postprocessor(
         t0=seq.t0,
@@ -87,12 +100,10 @@ def _run_group(client, cfg, rate=None, reset=None):
         for branch_id in group:
             if reset:
                 reset()
-            branch = branch_map[branch_id]
             _run_branch(
                 client,
                 cfg,
-                background_fname=branch["fname"],
-                shifts=branch["shifts"],
+                branch=branch_map[branch_id],
                 outdir=Path(cfg.outdir_root) / branch_id,
                 rate=rate,
             )
@@ -105,6 +116,7 @@ def _shared_args(p):
     p.add_argument("--branch_map", type=str)
     p.add_argument("--group_id", type=int)
     p.add_argument("--branches_per_job", type=int)
+    p.add_argument("--analysis_type", type=str, default="hdf5")
     p.add_argument("--waveforms", type=str)
     p.add_argument("--outdir_root", type=str)
     p.add_argument("--return_timeseries", type=bool, default=False)
@@ -150,6 +162,7 @@ def main_local(args=None):
     p.add_argument("--kernel_length", type=float)
     p.add_argument("--highpass", type=float)
     p.add_argument("--fftlength", type=float | None, default=None)
+    p.add_argument("--channel", type=str, default=None)  # R&P frames
     cfg = p.parse_args(args)
     if cfg.logfile is not None:
         Path(cfg.logfile).parent.mkdir(parents=True, exist_ok=True)

--- a/projects/infer/infer/data.py
+++ b/projects/infer/infer/data.py
@@ -1,12 +1,26 @@
 import logging
 import math
+import re
 import time
+from abc import ABC, abstractmethod
+from pathlib import Path
 from zlib import adler32
 
 import h5py
 import numpy as np
+from gwpy.timeseries import TimeSeriesDict
 from ledger.events import EventSet, RecoveredInjectionSet
 from ledger.injections import InterferometerResponseSet, waveform_class_factory
+
+FNAME_PATTERNS = {
+    "prefix": "[a-zA-Z0-9_:-]+",
+    "start": "[0-9]{10}",
+    "duration": "[1-9][0-9]*",
+    "suffix": "(gwf)|(hdf5)|(h5)",
+}
+FNAME_GROUPS = {k: f"(?P<{k}>{v})" for k, v in FNAME_PATTERNS.items()}
+FNAME_PATTERN = "{prefix}-{start}-{duration}.{suffix}".format(**FNAME_GROUPS)
+FNAME_RE = re.compile(FNAME_PATTERN)
 
 
 def _throttle(deadline: float, interval: float) -> float:
@@ -21,7 +35,127 @@ def _throttle(deadline: float, interval: float) -> float:
     return max(now, deadline) + interval
 
 
-class Sequence:
+class BaseSequence(ABC):
+    """Iterate over a segment of data, yielding (background, injected) batches
+    and aggregating the inference responses returned through __call__.
+
+    Subclasses supply source-specific setup and iteration.
+    Everything else is shared.
+    """
+
+    def __init__(
+        self,
+        inference_sampling_rate: float,
+        batch_size: int,
+        rate: float | None = None,
+        **kwargs,
+    ):
+        self.inference_sampling_rate = inference_sampling_rate
+        self.batch_size = batch_size
+        self.rate = rate
+
+        # Subclasses set sample_rate, size, t0, duration, and shifts.
+        self._setup(**kwargs)
+
+        self.stride = int(self.sample_rate / inference_sampling_rate)
+        self.step_size = self.stride * batch_size
+
+        # a semi-unique sequence id from a hash of the descriptive metadata
+        fingerprint = f"{self.t0}{self.duration}{self.shifts}".encode()
+        self.id = adler32(fingerprint)
+        self._initialize_sequence_state()
+
+    @abstractmethod
+    def _setup(self, **kwargs):
+        """Set sample_rate, size, t0, duration, and shifts."""
+
+    @property
+    @abstractmethod
+    def inference_filename(self) -> str:
+        """The file this sequence reads, for logging."""
+
+    @property
+    @abstractmethod
+    def has_foreground(self) -> bool:
+        """Whether a foreground sequence is produced."""
+
+    def _initialize_sequence_state(self):
+        self._started = {}
+        self._done = {}
+        self._sequences = {}
+        size = len(self) * self.batch_size
+        for i in range(2):
+            seq_id = self.id + i
+            self._started[seq_id] = False
+            self._done[seq_id] = False
+            self._sequences[seq_id] = np.zeros(size)
+
+    @property
+    def started(self):
+        return all(self._started.values())
+
+    @property
+    def done(self):
+        return all(self._done.values())
+
+    @property
+    def remainder(self):
+        # number of remaining data points not filling a full batch
+        return (self.size - max(self.shifts)) % self.step_size
+
+    @property
+    def num_pad(self):
+        # zeros needed to pad the last batch to a full batch
+        return (self.step_size - self.remainder) % self.step_size
+
+    @property
+    def slice(self) -> slice:
+        # inference requests to slice off the end to drop the padded dummy data
+        num_slice = self.num_pad // self.stride
+        end = -num_slice if num_slice else None
+        return slice(end)
+
+    def __len__(self):
+        # includes the trailing excess that can't fill a full batch; we pad it
+        # with zeros and slice the corresponding outputs back off afterward
+        return math.ceil((self.size - max(self.shifts)) / self.step_size)
+
+    def _get_data_indices(self, batch_idx: int, shift: int = 0):
+        last = batch_idx == len(self) - 1
+        start = batch_idx * self.step_size + shift
+        end = start + self.step_size
+        # the last batch steps only by the remainder before padding
+        if last and self.remainder:
+            end = start + self.remainder
+        return start, end, last
+
+    def _pad_last_batch(self, data: np.ndarray):
+        return np.pad(data, ((0, 0), (0, self.num_pad)), "constant")
+
+    def __call__(self, y, request_id, sequence_id):
+        # insert the response at the right spot in the output array
+        start = request_id * self.batch_size
+        stop = (request_id + 1) * self.batch_size
+        self._sequences[sequence_id][start:stop] = y[:, 0]
+
+        self._started[sequence_id] = True
+        if request_id == len(self) - 1:
+            self._done[sequence_id] = True
+
+        # once both sequences finish, return them, slicing off the padded tail
+        if self.done:
+            background = self._sequences[self.id][self.slice]
+            foreground = None
+            if self.has_foreground:
+                foreground = self._sequences[self.id + 1][self.slice]
+            return background, foreground
+
+    @abstractmethod
+    def recover(self, foreground: EventSet):
+        """Map recovered foreground events back to any injections."""
+
+
+class Hdf5Sequence(BaseSequence):
     def __init__(
         self,
         background_fname: str,
@@ -33,13 +167,12 @@ class Sequence:
         rate: float | None = None,
     ):
         """
-        Object used for iterating over a segment of data,
-        performing timeshifts, optionally injecting waveforms, and
-        aggregating the returned inference outputs.
+        Iterate over a background segment, performing timeshifts, optionally
+        injecting waveforms, and aggregating the returned inference outputs.
 
-        If the injection set is empty for this given
-        segment and shifts, infernece on injections will be skipped,
-        and `None` will be returned for the foreground events.
+        If the injection set is empty for this segment and shifts, inference
+        on injections is skipped and `None` is returned for the foreground
+        events.
 
         Args:
             background_fname:
@@ -58,16 +191,33 @@ class Sequence:
                 Rate at which to send requests in Hz
         """
         logging.info("Initializing sequence")
+        super().__init__(
+            inference_sampling_rate=inference_sampling_rate,
+            batch_size=batch_size,
+            rate=rate,
+            background_fname=background_fname,
+            injection_set_fname=injection_set_fname,
+            ifos=ifos,
+            shifts=shifts,
+        )
+        # with no injections, mark the foreground sequence already complete
+        if self.injection_set is None:
+            self._done[self.id + 1] = True
+            self._started[self.id + 1] = True
 
+    def _setup(
+        self,
+        background_fname: str,
+        injection_set_fname: str,
+        ifos: list[str],
+        shifts: list[float],
+    ):
         self.background_fname = background_fname
-        self.inference_sampling_rate = inference_sampling_rate
-        self.batch_size = batch_size
-        self.rate = rate
         self.ifos = ifos
 
         if len(ifos) != len(shifts):
             raise ValueError(
-                "Number of ifos must match number of shifts"
+                "Number of ifos must match number of shifts; "
                 f"got {len(ifos)} ifos and {len(shifts)} shifts"
             )
 
@@ -79,17 +229,12 @@ class Sequence:
             self.t0 = dataset.attrs["x0"]
             self.duration = self.size / self.sample_rate
 
-        # load in our injections up front
-        # if there are no injections for
-        # this shift, set it to None so
-        # we don't run inference on injections
-
+        # load injections up front. None means skip inference on injections
         cls = waveform_class_factory(
             ifos,
             InterferometerResponseSet,
             "ResponseSet",
         )
-
         injection_set = cls.read(
             injection_set_fname,
             start=self.t0,
@@ -105,72 +250,15 @@ class Sequence:
             injection_set = None
 
         self.injection_set = injection_set
-
-        # derive some properties from that metadata,
-        # including come up with a semi-unique sequence
-        # id derived from a hash of its most descriptive parts
-        fingerprint = f"{self.t0}{self.duration}{shifts}".encode()
-        self.id = adler32(fingerprint)
-        self.shifts = [int(i * self.sample_rate) for i in shifts]
-        self.stride = int(self.sample_rate / inference_sampling_rate)
-        self.step_size = self.stride * batch_size
-        # initialize some containers for handling during
-        # the inference response callback
-        self._started = {}
-        self._done = {}
-        self._sequences = {}
-        size = len(self) * self.batch_size
-        for i in range(2):
-            seq_id = self.id + i
-            self._started[seq_id] = False
-            self._done[seq_id] = False
-            self._sequences[seq_id] = np.zeros(size)
-
-        # if there are no injections, we can mark
-        # the injection sequence as started and done
-        if self.injection_set is None:
-            self._done[self.id + 1] = True
-            self._started[self.id + 1] = True
+        self.shifts = np.array([int(i * self.sample_rate) for i in shifts])
 
     @property
-    def started(self):
-        return all(self._started.values())
+    def inference_filename(self):
+        return self.background_fname
 
     @property
-    def done(self):
-        return all(self._done.values())
-
-    @property
-    def remainder(self):
-        # the number of remaining data points not filling a full batch
-        return (self.size - max(self.shifts)) % self.step_size
-
-    @property
-    def num_pad(self):
-        # the number of zeros we need to pad the last batch
-        # to make it a full batch
-        return (self.step_size - self.remainder) % self.step_size
-
-    @property
-    def slice(self) -> slice:
-        """
-        The number of inference requests we need to slice
-        off the end of the sequences to remove
-        the dummy data from the last batch
-        """
-
-        # if num_pad is 0 don't slice anything
-        num_slice = self.num_pad // self.stride
-        end = -num_slice if num_slice else None
-        return slice(end)
-
-    def __len__(self):
-        # this include excess data at end of sequence that can't
-        # be used for a full batch. We'll end up padding it
-        # with zeros to make it a full batch and
-        # slicing off the actual useful inference requests
-        # corresponding to the excess
-        return math.ceil((self.size - max(self.shifts)) / self.step_size)
+    def has_foreground(self):
+        return self.injection_set is not None
 
     def __iter__(self):
         # rate is the average number of requests per second. Each yield is
@@ -180,35 +268,14 @@ class Sequence:
 
         with h5py.File(self.background_fname, "r") as f:
             for i in range(len(self)):
-                # if this is the last batch, we may need to pad it
-                # to make it a full batch
-                last = i == len(self) - 1
-                # grab the current batch of updates from the file
-                # and stack it into a 2D array
                 x = []
                 for ifo, shift in zip(self.ifos, self.shifts, strict=True):
-                    start = shift + i * self.step_size
-
-                    # for all but last batch just
-                    # increase by step size
-                    end = start + self.step_size
-
-                    # if this is the last batch
-                    # and we need to pad it
-                    # just step by the remainder
-                    if last and self.remainder:
-                        end = start + self.remainder
-
-                    data = f[ifo][start:end]
-                    # if this is the last batch
-                    # possibly pad it to make it a full batch
-                    if last:
-                        data = np.pad(data, (0, self.num_pad), "constant")
-
-                    x.append(data)
+                    start, end, last = self._get_data_indices(i, shift)
+                    x.append(f[ifo][start:end])
                 x = np.stack(x).astype(np.float32)
-                # if there are any injections for this shift,
-                # inject waveforms into a copy of the background
+                x = self._pad_last_batch(x) if last else x
+
+                # inject waveforms into a copy of the background, if any
                 x_inj = None
                 offset = i * self.batch_size / self.inference_sampling_rate
                 if self.injection_set is not None:
@@ -216,33 +283,101 @@ class Sequence:
                         x.copy(), self.t0 + offset
                     )
 
-                # return the two sets of updates, throttled to rate
                 deadline = _throttle(deadline, interval)
                 yield x, x_inj
 
-    def __call__(self, y, request_id, sequence_id):
-        # insert the response at the appropriate
-        # spot in the corresponding output array
-        start = request_id * self.batch_size
-        stop = (request_id + 1) * self.batch_size
-        self._sequences[sequence_id][start:stop] = y[:, 0]
-
-        # indicate that the first response for
-        # this sequence has returned, and possibly
-        # that the last one has returned as well
-        self._started[sequence_id] = True
-        if request_id == len(self) - 1:
-            self._done[sequence_id] = True
-
-        # if both the background and foreground
-        # sequences have completed, return them both,
-        # slicing off the dummy data from the last batch
-        if self.done:
-            background = self._sequences[self.id][self.slice]
-            foreground = None
-            if self.injection_set is not None:
-                foreground = self._sequences[self.id + 1][self.slice]
-            return background, foreground
-
     def recover(self, foreground: EventSet) -> RecoveredInjectionSet:
         return RecoveredInjectionSet.recover(foreground, self.injection_set)
+
+
+class RnPSequence(BaseSequence):
+    def __init__(
+        self,
+        injection_file: Path,
+        channel: str,
+        ifos: list[str],
+        sample_rate: float,
+        inference_sampling_rate: float,
+        batch_size: int,
+    ):
+        """
+        Iterate over an injection frame that already contains injected signals.
+        The same data is yielded as both "background" and "foreground", with
+        no event recovery performed.
+
+        Each sequence is one frame, so the PSD burn-in is performed on each
+        frame. PSD length should be short enough that this doesn't impact
+        performance much.
+
+        Args:
+            injection_file:
+                R&P injection frame file to analyze
+            channel:
+                Channel name within the frame, combined as {ifo}:{channel}
+            ifos:
+                Interferometer names
+            sample_rate:
+                Sample rate the data is resampled to for inference
+            inference_sampling_rate:
+                Rate at which inference is performed
+            batch_size:
+                Number of inference requests to send to the model at once
+        """
+        logging.info("Initializing sequence")
+        self.sample_rate = sample_rate
+        # always in-process: no server to throttle, so rate is always None
+        super().__init__(
+            inference_sampling_rate=inference_sampling_rate,
+            batch_size=batch_size,
+            rate=None,
+            injection_file=injection_file,
+            channel=channel,
+            ifos=ifos,
+        )
+
+    def _setup(
+        self,
+        injection_file: Path,
+        channel: str,
+        ifos: list[str],
+    ):
+        self.ifos = ifos
+        # Don't shift timeseries for R&P injections
+        self.shifts = np.zeros(len(ifos), dtype=int)
+        self.channels = [f"{ifo}:{channel}" for ifo in ifos]
+
+        self.injection_file = Path(injection_file)
+        match = FNAME_RE.search(self.injection_file.name)
+        if not match:
+            raise ValueError(
+                f"{self.injection_file.name} does not match expected pattern"
+            )
+        self.t0 = int(match.group("start"))
+        self.duration = int(match.group("duration"))
+        self.size = int(self.duration * self.sample_rate)
+
+        injected = TimeSeriesDict.read(
+            self.injection_file, channels=self.channels
+        ).resample(self.sample_rate)
+        self.timeseries = np.stack(
+            [injected[ch].value for ch in self.channels]
+        ).astype(np.float32)
+
+    @property
+    def inference_filename(self):
+        return self.injection_file.name
+
+    @property
+    def has_foreground(self):
+        return True
+
+    def __iter__(self):
+        for i in range(len(self)):
+            start, end, last = self._get_data_indices(i)
+            x_inj = self.timeseries[:, start:end]
+            x_inj = self._pad_last_batch(x_inj) if last else x_inj
+            # yield the same data as background and foreground
+            yield x_inj, x_inj
+
+    def recover(self, foreground: EventSet) -> EventSet:
+        return foreground

--- a/projects/infer/infer/main.py
+++ b/projects/infer/infer/main.py
@@ -5,13 +5,13 @@ import numpy as np
 from hermes.aeriel.client import InferenceClient
 from tqdm import tqdm
 
-from infer.data import Sequence
+from infer.data import BaseSequence
 from infer.postprocess import Postprocessor
 
 
 def infer(
     client: InferenceClient,
-    sequence: Sequence,
+    sequence: BaseSequence,
     postprocessor: Postprocessor,
 ):
     """
@@ -34,7 +34,7 @@ def infer(
     """
     logging.info(
         f"Beginning inference on sequence {sequence.id} corresponding "
-        f"to {sequence.duration}s of data from {sequence.background_fname} "
+        f"to {sequence.duration}s of data from {sequence.inference_filename} "
         f"with shifts {sequence.shifts / sequence.sample_rate} and "
         f"sample rate {sequence.sample_rate}, beginning at "
         f"GPS time {sequence.t0}"

--- a/projects/infer/pyproject.toml
+++ b/projects/infer/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "utils",
     "ledger",
     "urllib3>=2",
+    "gwpy>=3.0",
 ]
 
 [project.scripts]

--- a/projects/infer/scripts/aggregate_infer.py
+++ b/projects/infer/scripts/aggregate_infer.py
@@ -18,6 +18,15 @@ with open(snakemake.input.branch_map) as f:
     branch_map = json.load(f)
 
 tmp_dir = Path(snakemake.params.tmp_dir)
+# Only split zero-shift branches out when a zero_lag output is requested.
+# Otherwise, everything is in background.hdf5 (useful for R&P analysis)
+split_zero_lag = hasattr(snakemake.output, "zero_lag")
+# R&P foregrounds are plain EventSets, not RecoveredInjectionSets.
+foreground_cls = (
+    EventSet
+    if snakemake.params.analysis_type == "rnp"
+    else RecoveredInjectionSet
+)
 background, zero_lag, foreground = [], [], []
 background_length, zero_lag_length, foreground_length = 0, 0, 0
 
@@ -29,7 +38,7 @@ for branch_id, branch in branch_map.items():
         meta = json.load(f)
     foreground.append(fg)
     foreground_length += meta["foreground_length"]
-    if all(s == 0 for s in branch["shifts"]):
+    if split_zero_lag and all(s == 0 for s in branch["shifts"]):
         zero_lag.append(bg)
         zero_lag_length += meta["background_length"]
     else:
@@ -43,7 +52,7 @@ EventSet.aggregate(
     clean=True,
     length=background_length,
 )
-RecoveredInjectionSet.aggregate(
+foreground_cls.aggregate(
     foreground,
     snakemake.output.foreground,
     clean=True,

--- a/projects/infer/uv.lock
+++ b/projects/infer/uv.lock
@@ -437,6 +437,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
 name = "cloudpathlib"
 version = "0.18.1"
 source = { registry = "https://pypi.org/simple" }
@@ -581,6 +593,21 @@ wheels = [
 ]
 
 [[package]]
+name = "dateparser"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "regex" },
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/f4/561c49bca97af561d34eed27e3e831135eb5cb88e754c1150be41820f5c6/dateparser-1.4.1.tar.gz", hash = "sha256:f265df13c0380e2e07543ba74b67c0681aaa1096981ffcd35227e1aa0cb81c7c", size = 314734, upload-time = "2026-06-15T08:45:47.659Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/7c/2e5dcf53909deddd0bf38cbe277ad9806be038276b1c6c436561b4d9b2e2/dateparser-1.4.1-py3-none-any.whl", hash = "sha256:f25d4e051a84be27a35bd297e3e1dc59ff78373701b89be352ba80372d22d0d0", size = 300503, upload-time = "2026-06-15T08:45:45.951Z" },
+]
+
+[[package]]
 name = "debugpy"
 version = "1.8.12"
 source = { registry = "https://pypi.org/simple" }
@@ -613,6 +640,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
+name = "dqsegdb2"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "igwn-auth-utils" },
+    { name = "igwn-segments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/37/7874b39abede48fe05c3b5a25092e419e521145e9705c97b711965e5f05d/dqsegdb2-1.3.0.tar.gz", hash = "sha256:4e291899cd395daf5913c48a835d213ef20833d78354871cb848988cc2cc8ae4", size = 33661, upload-time = "2025-01-08T16:36:58.072Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/67/c977e7307d432911fe28acf55dba01f84f3a0a4a2a968350195c0f52d23e/dqsegdb2-1.3.0-py3-none-any.whl", hash = "sha256:c93087da332b7d91519a370abed3cfc91b64a6bf393ec64d79c2747c837aeb66", size = 27957, upload-time = "2025-01-08T16:36:56.881Z" },
 ]
 
 [[package]]
@@ -764,15 +805,54 @@ wheels = [
 
 [[package]]
 name = "gwdatafind"
-version = "1.2.0"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "igwn-auth-utils" },
-    { name = "ligo-segments" },
+    { name = "igwn-segments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/10/9f1b9100f59e2ca4a85dad8a21942d0702d756f4b80a433c728be4a871d2/gwdatafind-1.2.0.tar.gz", hash = "sha256:8f74942e66cdb9a53030da29069110b3cb30afc2a034790957786028fb09f451", size = 40381, upload-time = "2023-12-18T09:19:43.234Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/dd/4f517a2a36f71d5bb74b8b0796e3fec87703587503d4583f4a5b962ae60b/gwdatafind-2.1.1.tar.gz", hash = "sha256:e4710256daa7b47e901da2f2846620c551e9caaaaf22b7773c81a8ae052da43e", size = 41311, upload-time = "2025-10-31T09:46:57.9Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/61/5020eff070e04b1e07c7cf8bed63705aa705011e057cbb839e9a31367bdd/gwdatafind-1.2.0-py3-none-any.whl", hash = "sha256:58c505ee188c1186ff81b3de5f946f289179a4f8c334f7eb45d07dd70a71bd2c", size = 45529, upload-time = "2023-12-18T09:19:41.129Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/00/07a1a9473ea5bbbc0be3cea79778dfd31e7e199404777907930badc9f399/gwdatafind-2.1.1-py3-none-any.whl", hash = "sha256:6e6d430fa243e6241ca0c214f1916f7973cf1937716bbca52d99a9b88650faeb", size = 45178, upload-time = "2025-10-31T09:46:56.468Z" },
+]
+
+[[package]]
+name = "gwosc"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "tenacity" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/28/3dfccc399aca4da49354fb612ade049950ec73b4b34ec1089bb7dbb5a7fb/gwosc-0.8.2.tar.gz", hash = "sha256:6a7a97f1fd86184841f2f9d83eeccf9b3fc889104d8018ecb08276a1a4f6336b", size = 35171, upload-time = "2026-04-02T19:00:17.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/da/f3f9983547f257de9d359bcc358cdc8254b8cb00d78fe692a60b463f0ff0/gwosc-0.8.2-py3-none-any.whl", hash = "sha256:ec1ecc667e9b148e8229c0a71290921eec4e60c674096d3d639c9f44c198efeb", size = 35151, upload-time = "2026-04-02T19:00:16.09Z" },
+]
+
+[[package]]
+name = "gwpy"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "astropy" },
+    { name = "dateparser" },
+    { name = "dqsegdb2" },
+    { name = "gwdatafind" },
+    { name = "gwosc" },
+    { name = "h5py" },
+    { name = "igwn-segments" },
+    { name = "ligotimegps" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+    { name = "scipy" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/71/1e652734a0e8f23e0f9dbf5df5698e66fa49aef4446d2c6c9eb914921192/gwpy-4.0.1.tar.gz", hash = "sha256:477aa69bd40506bfb0df5ec779d9dd6fef562a3bfabe58a52b297e25c57f61f0", size = 1615849, upload-time = "2026-02-03T10:14:59.045Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/ac/1debaaec791da4475687d22c8c2cbccc2008885046754f5e9f65997886b8/gwpy-4.0.1-py3-none-any.whl", hash = "sha256:587eb66443e41450bd89bf64891e323943afad3be385fccc1645eda2710908b7", size = 1559010, upload-time = "2026-02-03T10:14:56.928Z" },
 ]
 
 [[package]]
@@ -873,11 +953,32 @@ wheels = [
 ]
 
 [[package]]
+name = "igwn-segments"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ef/3500687ef4a61887bc218ab7ef8352ab7110afababaa82e958f2ca95967b/igwn_segments-2.1.1.tar.gz", hash = "sha256:672814d78f5de7582b5f39189cdc6016d7ffde95d2b8b8b8b82aa9b45e53f3dd", size = 60805, upload-time = "2026-01-19T17:51:05.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/c3/3ba15630cf8b873cb10bf188793b7828cf2f7e13ba0bd5673bdad42e8636/igwn_segments-2.1.1-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:774c84a5c0ebf4fe6e4de3e1b8c73c02b6f53db96598a07e7d26de9cd156ef64", size = 49068, upload-time = "2026-01-19T17:50:32.953Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b1/7ffbe8b7fe6b6597d913bfd32db3898ee3d1495003bfedd497b14ea696b9/igwn_segments-2.1.1-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:8cc0dde1d4f9de3a36eddf38e25baa166492737c93ad71658db25dfc46745ddd", size = 49249, upload-time = "2026-01-19T17:50:34.158Z" },
+    { url = "https://files.pythonhosted.org/packages/71/f7/9110ee0e83f43ba97155897be0a864d53801ff259a674bc8e37f80e854b9/igwn_segments-2.1.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c2231f6a8e2adeb6403e4ba5fa8fb9cd9bcb7c55fa9e67e90139020a32aff79", size = 112480, upload-time = "2026-01-19T17:50:35.064Z" },
+    { url = "https://files.pythonhosted.org/packages/50/06/eb25c8ffefcbe8c9f3275855bbfad607e20d61ea6c3f5be778f8b5c0d82f/igwn_segments-2.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cfbef53fcd95c56e200b9211cd3bad4fa48c5b82586166c6fdb44306ea3b9289", size = 114264, upload-time = "2026-01-19T17:50:36.092Z" },
+    { url = "https://files.pythonhosted.org/packages/84/18/ce2b83e8993ddb4d8f6c409ff3405f3e424215a88876b019f7a0d9b38d70/igwn_segments-2.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5ba2483b066c8f95e6e916437f7a375c0497313e1a425642b89ef1d647980f80", size = 112686, upload-time = "2026-01-19T17:50:37.479Z" },
+    { url = "https://files.pythonhosted.org/packages/13/78/ec606472610da3f545cbdd03b134fc09cfb86eae3674f5198ee8a4c36501/igwn_segments-2.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5351901272f8a33b4cb8546930e744bcd912c5d899879e8477f064cd11d0d874", size = 111852, upload-time = "2026-01-19T17:50:38.627Z" },
+    { url = "https://files.pythonhosted.org/packages/71/78/6764ceb793728334df4dc87d9089ca5a8010ad280c7ca13c0e4304818f83/igwn_segments-2.1.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:d8a1e36f21f9420f254a7f78c289035c8d9dc4e0f44b5a77495e87d71469bd7b", size = 49329, upload-time = "2026-01-19T17:50:39.843Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/76/eb614178340cbae66af617303f80748d61d74c57f0b02105b9ca85c90033/igwn_segments-2.1.1-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:139abaec24edc25e7409fe48445c5aa8d9448e98c038079d84485497abc838c0", size = 49704, upload-time = "2026-01-19T17:50:41.013Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/5c/f10140682e77bdf4160cd474bbc21a8e8d362dfec46131b4e66d5929b04e/igwn_segments-2.1.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f550aa55fa4165c1d3d8571d67523a010b5b365ee363516e542f732cbe54a1d8", size = 114953, upload-time = "2026-01-19T17:50:42.126Z" },
+    { url = "https://files.pythonhosted.org/packages/61/05/b347e6ac22c5cbae568e410c56729a188d9d64ce340e859fc8db5b82f195/igwn_segments-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9aa802dfd96d24909975d92c24aee088d4be0fb3636a2d893cb196bbeb19f175", size = 115998, upload-time = "2026-01-19T17:50:43.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a5/f6a2b14786e62630fa3adad1b87155c4d71c3b1360e8563092793b81dfae/igwn_segments-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:74abd9ab5502bfba09343d2d6fcffb7c75f935385e1ca389b8ced82e9fe67a8f", size = 114540, upload-time = "2026-01-19T17:50:44.438Z" },
+    { url = "https://files.pythonhosted.org/packages/48/9e/604b28e22207db111c9f43e4214a7aa086d6d65be38c024d393a5aaab781/igwn_segments-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:029a7d55c786ef24f1c07850a291e111ef2fceeaae2518347203dcaa019f811c", size = 114640, upload-time = "2026-01-19T17:50:45.749Z" },
+]
+
+[[package]]
 name = "infer"
 version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "aframe" },
+    { name = "gwpy" },
     { name = "jsonargparse" },
     { name = "ledger" },
     { name = "ml4gw-hermes", extra = ["torch"] },
@@ -898,6 +999,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aframe", editable = "../../" },
+    { name = "gwpy", specifier = ">=3.0" },
     { name = "jsonargparse", specifier = "~=4.24" },
     { name = "ledger", editable = "../../libs/ledger" },
     { name = "ml4gw-hermes", extras = ["torch"], git = "https://github.com/ML4GW/hermes?branch=dev" },
@@ -1439,6 +1541,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/81/60/8de5c89e4e5fc7606
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/db/b2de07a032a766d34480e93e6d4ecda5a4d651bb6a5e3286c2624d6c181d/ligo_segments-1.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:da82ae2b839bad0027e0a492b3673344e62360747d41194a265563e6c2903c7d", size = 50007, upload-time = "2022-11-02T16:54:29.221Z" },
     { url = "https://files.pythonhosted.org/packages/b5/37/c962f26408ce45271a5a3aaa918f7beae74a8e8a6f00bbe5fdf77fd778ca/ligo_segments-1.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:601be6d92e52bdebbb5a82b608ed1ceb781a0ea86b3e5333d61af77575b32664", size = 50555, upload-time = "2023-10-09T11:39:10.788Z" },
+]
+
+[[package]]
+name = "ligotimegps"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/9b/521be61daa7603603826d40fa6327a22e04df4f20e69d9ed42182370a7f8/ligotimegps-2.1.0.tar.gz", hash = "sha256:d948ffc4d58472b303478a983ec56d2e6a7f35e54cbb351ca6f1292e68398cb2", size = 28069, upload-time = "2025-10-07T10:55:28.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/92/38674acb59c663bcdb69522e11afd3b4e6371f74b5764aeec2e99308cd79/ligotimegps-2.1.0-py3-none-any.whl", hash = "sha256:14dbbb07b175b94b4e1a519d7baa4548f0ea07bc71ef7d7f096ad8397d359043", size = 23370, upload-time = "2025-10-07T10:55:28.855Z" },
 ]
 
 [[package]]
@@ -2497,6 +2608,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pytz"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
+]
+
+[[package]]
 name = "pywin32"
 version = "308"
 source = { registry = "https://pypi.org/simple" }
@@ -2592,6 +2712,46 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744, upload-time = "2025-01-25T08:48:16.138Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/b1/3baf80dc6d2b7bc27a95a67752d0208e410351e3feb4eb78de5f77454d8d/referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0", size = 26775, upload-time = "2025-01-25T08:48:14.241Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/dc/c1f2df4027e82fc54b5a473e4b250f5139faca49a0fbe29a48668d228f34/regex-2026.5.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ccf5249114cc3e772ecdd88a98a86eca0fd74c61ce32a94743758c083fc05d48", size = 489445, upload-time = "2026-05-09T23:12:06.111Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d2/59f01110660081cce9c0bc30ebd0b5ee250dacf658e3248ed92f01e0e8ee/regex-2026.5.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:46f1326ca6e65b0879d23ca302c0f2415aad42ff0309b9c818e7949fe19a41d8", size = 291271, upload-time = "2026-05-09T23:12:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/58/b6/14b2c84ff90ddb370c81d27503f4a0fcf071496416f4855f6cc8c5d81c35/regex-2026.5.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ef31cbfe458e21c6122ba8150ff060e0c7789ed0d26eb423f25472584920b555", size = 289212, upload-time = "2026-05-09T23:12:09.266Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d0/4db86529117320de0c84afd90e70bb47434625875e34fcef9d8c127c5b16/regex-2026.5.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:992604d02e6d9c6d786c24a706a71ecffe1020fc1ef264044474cd81fa2c3919", size = 792310, upload-time = "2026-05-09T23:12:11.416Z" },
+    { url = "https://files.pythonhosted.org/packages/07/78/fe4800cd322f862ecffd2d553409b20d80650e5ed71b9d178f853d020b82/regex-2026.5.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9411dd64ca95477225734a93dfc8583b51916b8d5942f99d6cac21e09965451", size = 861721, upload-time = "2026-05-09T23:12:13.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d0/b3618a895dd8feb897c61bb2954edd265e1767d82a01d53065d5871127a3/regex-2026.5.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3dd4a3ff360dfb836fecdb93a4598f9d6e2ac81e3e397125145c6221bf58cf4c", size = 906460, upload-time = "2026-05-09T23:12:15.443Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6f/1481597e859ef19508b345eec4afd1416ed6e6b459c75a64026ef193aecf/regex-2026.5.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a661a7d270a61f7cf460caee8b9fa2d5ef9e5c681234bcb9e0fe14f488e7dfc", size = 799843, upload-time = "2026-05-09T23:12:16.892Z" },
+    { url = "https://files.pythonhosted.org/packages/73/59/955734c803f59108deccba3597ae440c76b62a652733c0006e6243758420/regex-2026.5.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f079e50a0d3cc3cd5091fa9ff45869a2e6b2cd35895731edafb0327901a8d86d", size = 773610, upload-time = "2026-05-09T23:12:19.127Z" },
+    { url = "https://files.pythonhosted.org/packages/68/8f/70c04a236d651c81881dac42ef8538bddda6121434509d0a22d9e601503b/regex-2026.5.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4ebe8f0b5ec5a5024dc4a4c59f444c4e9afc5f2abdbb8962065b75d27fb971f9", size = 781645, upload-time = "2026-05-09T23:12:20.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/96/05c7434d88185e5d27fe54aeb74df86bd77cd79f52f0b4eae54faa8fea70/regex-2026.5.9-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:97cf3bc1b7d7d2306772ec07366c80d9df00ff79e79cea32898883a646d2fae2", size = 854473, upload-time = "2026-05-09T23:12:22.465Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/6e3d8202d981f3117004bf341ee74893ba4ba8a9fbaf4b94615846550a08/regex-2026.5.9-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0f9eede6a5cbdc02d4978090186390936e1776a7d1359b21e41014c609880bcf", size = 763311, upload-time = "2026-05-09T23:12:24.351Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c7/e7737f1526b3fb32bd4c337fd6c71c3ebb5c8296fc34d11197e0955d2e35/regex-2026.5.9-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:01f0f5f55f4b64dacec85dc116d3c05fd23ad3ff037bbc73a2085775953c2611", size = 844593, upload-time = "2026-05-09T23:12:26.341Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/27/0daffb1a535bb39f422c3d200f4ab023c71110ad66a32b366bee708baba0/regex-2026.5.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1268eddd8486dc561d08eee1156e40aa3a8fe10f4bdec8fa653b455fcbffd12c", size = 789167, upload-time = "2026-05-09T23:12:27.975Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fc/294fe4fac4f2ed67207b17471815870c1c45b3a489e08e0ac96daea16ef6/regex-2026.5.9-cp311-cp311-win32.whl", hash = "sha256:8676474c07469d6f33dd1085ca2cd45f65785f32518f2b20e36d9953ca07f994", size = 266249, upload-time = "2026-05-09T23:12:30.141Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b0/8dce459f6245bcf8f6e9f23ac9569f1a0f15c131cc0745e82b43226204cf/regex-2026.5.9-cp311-cp311-win_amd64.whl", hash = "sha256:246de9d60aa3f8538b519834dd95cbf276ea263d6a7bd5a3666dc3fa0230505b", size = 278423, upload-time = "2026-05-09T23:12:31.676Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8d/f9aeff6ad63a3ef720386f2907e6d34a35a510a6e498ebad28b0fb3f6ab6/regex-2026.5.9-cp311-cp311-win_arm64.whl", hash = "sha256:d726ca3f0d76969bf1e8e477d160d3d666bbf999f6860bd314889e5345782046", size = 270420, upload-time = "2026-05-09T23:12:33.194Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9b/6550044bc44e17c84d312c031c2ec42fbdb6a4ec4e29093be3a172d08772/regex-2026.5.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57eeeb05db7979413dec5438f2db21d7ecbba787cde7a711df1a6f6df672aa06", size = 490451, upload-time = "2026-05-09T23:12:34.72Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/95/fc7ba4303b5a0f92446a12ee6778ef2c6c799233f5060042a31bf390cfe9/regex-2026.5.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:398c521292f4c7fb807001dcd54694d3a1fcafc179a36ad9cc56f98df85930b6", size = 292112, upload-time = "2026-05-09T23:12:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4b/ee27938d1b2c443e89a9a10e00d2d19aa5ee300cd3d61140644e93bb083e/regex-2026.5.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f7a7c26137296beba7784de6eba69c6a93a63ccebc385e4962fe67e267a91225", size = 289599, upload-time = "2026-05-09T23:12:38.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/dd/ba103dc19614e25f3880800ca67ce093d6e21b325d72b8383c7bf906e9fa/regex-2026.5.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6441cc660d76107934a09c22167200839a0e89604a6297f78a974e66e931d2c0", size = 796732, upload-time = "2026-05-09T23:12:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e7/f035b4fd858b050b0080bf302968dc0f59ba34e391872d54936758e6844e/regex-2026.5.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:91328f1c23d47595ca3ef0a7557fa129c5a23404b775c770697d2f35b33e0107", size = 865440, upload-time = "2026-05-09T23:12:42.059Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/51/8cd301ecc899aea28124357f729f4272f44de7806fc7ca02490bfbe253e8/regex-2026.5.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:93a7860539414dddaefba2b40f8771765ae17949d4c7182b876ce429e11a8309", size = 912329, upload-time = "2026-05-09T23:12:44.373Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1e/3fbe2fa1e8cebd62f3bb7d3321cff1640aca2e240b51d9bd624aad949260/regex-2026.5.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd2810d22146b6d838acc5ec15602cb6b47920aa4e33015df3868eedfd20bab8", size = 801239, upload-time = "2026-05-09T23:12:46.268Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2f/6f6008682bf2cf98040a0d3153a8e557b6ab728d7713d045cee4ce544ab8/regex-2026.5.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daff2bdbaf1d23e52fdff7c0b7bc2048b68f978df6a4d107ac981f94caef2e66", size = 777054, upload-time = "2026-05-09T23:12:48.051Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2b/eee0d20a6842ba04df4b8847a920b57ef56853f14ef85405473e586b605a/regex-2026.5.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4eeb011098fcb77af513dcef521a3dbecbf8849b1e38940759d293b7a93f5026", size = 785098, upload-time = "2026-05-09T23:12:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/98/6fc1e6410feefb92159edaed5041992bfe390e8d26c721865434acbca558/regex-2026.5.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ea9c8ecfa1b73c73b626534d6626e5340d429630943672b8480724f44e84b962", size = 860095, upload-time = "2026-05-09T23:12:51.666Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a3/bd855e0f2cb1a978ecf6fa6bb69632dd9c3f6ea3b81cde62fde14c9daec7/regex-2026.5.9-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cd2846168eb9ee3c513902bc8225409cb1caab31d04728b145171fa1625d9621", size = 765762, upload-time = "2026-05-09T23:12:53.413Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/66/0ae8c092e60b14c79d24f8e0b7f0aea5bfbffdcab00b5483d13404d3c3a5/regex-2026.5.9-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39617fb0cde9c0e6306dc70e3bfc096f3da793219879f7ae7aa341a69fbdcf6d", size = 852100, upload-time = "2026-05-09T23:12:55.256Z" },
+    { url = "https://files.pythonhosted.org/packages/21/de/8dfde60fc1b21c946a893ba273403b72617edb261370cb1087099a83f088/regex-2026.5.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd03c4f0e33280d15cae17159b899245d6b7c53d21def19b263b39655061f5ce", size = 789479, upload-time = "2026-05-09T23:12:57.573Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1c/bdcc98f9a4af4fdd166c74941174619ccff4726d3ce32faa8e9a2ecd38dd/regex-2026.5.9-cp312-cp312-win32.whl", hash = "sha256:164eba9b755ea6f244b0d881196fbc1fac09714e9782c9e2732b813142033c8e", size = 266699, upload-time = "2026-05-09T23:12:59.14Z" },
+    { url = "https://files.pythonhosted.org/packages/78/87/240d36864f9e48ace85f72e79ced97ceb7f27ce87739a947dcb834b4e6bc/regex-2026.5.9-cp312-cp312-win_amd64.whl", hash = "sha256:86f40a5d6444db30a125c9c9177e6b25dad981cbc37451fd838f145e6edac92e", size = 277783, upload-time = "2026-05-09T23:13:00.789Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b5/7b30f312b0669dff5beebe5b0989dc2d1a312b1a44fab852199c387a5b96/regex-2026.5.9-cp312-cp312-win_arm64.whl", hash = "sha256:96f5f58b54a063d7ea9dca08e1cf57bfe10499c4d579ee672da284f57f5f0070", size = 270513, upload-time = "2026-05-09T23:13:02.426Z" },
 ]
 
 [[package]]
@@ -3024,6 +3184,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321, upload-time = "2024-06-07T18:52:15.995Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438, upload-time = "2024-06-07T18:52:13.582Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/55/15e2340963d2bfedcc6042da3911438fd336f8ae96b65bdbe3a29766da0c/tzlocal-5.4.3.tar.gz", hash = "sha256:3a8c9bc18cf47e1dcde252ea0e6a72a6cde320a400b6ac6db1f1f8cccd553c00", size = 30873, upload-time = "2026-06-17T04:17:41.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/28/fc144409c71569e928585f8f3c629d80d1ca3ef40175e9222f01588f98c9/tzlocal-5.4.3-py3-none-any.whl", hash = "sha256:24ce97bb58e2a973f7640ec2553ab4e6f6d5a0d0d1aa9dc43bca21d89e1feb82", size = 18039, upload-time = "2026-06-17T04:17:40.027Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Built off of #504. Brings the law-based R&P changes from #432 into the Snakemake workflow.

I have not tested this whatsoever beyond making sure the DAG built, but hopefully it's a good starting point for analyzing injection frames. One change from the original PR: because I introduced `branches_per_job` in #504, I got rid of the concatenation of frames that was done in #432 just for the purposes of reducing complexity. As long as the PSD length is reduced from its usual 64 seconds to 16 seconds, I think that will be fine, given the spacing of injections. 